### PR TITLE
Add $(HELPER_DIR) and others to Makefile.common

### DIFF
--- a/template-for-repository/proofs/Makefile-project-defines
+++ b/template-for-repository/proofs/Makefile-project-defines
@@ -20,6 +20,11 @@
 # LINK_FLAGS =
 
 # Preprocessor include paths -I...
+# Consider adding
+#     INCLUDES += -I$(CBMC_ROOT)/include
+# You will want to decide what order that comes in relative to the other
+# include directories in your project.
+#
 # INCLUDES =
 
 # Preprocessor definitions -D...

--- a/template-for-repository/proofs/Makefile.common
+++ b/template-for-repository/proofs/Makefile.common
@@ -83,6 +83,9 @@ default: report
 # Absolute path to the directory containing this Makefile.common
 # See https://ftp.gnu.org/old-gnu/Manuals/make-3.80/html_node/make_17.html
 PROOF_ROOT = $(dir $(abspath $(filter %/Makefile.common,$(MAKEFILE_LIST))))
+CBMC_ROOT = $(shell dirname $(PROOF_ROOT))
+PROOF_STUB = $(CBMC_ROOT)/stubs
+PROOF_SOURCE = $(CBMC_ROOT)/sources
 
 # Project-specific definitions to override default definitions below
 #   * Makefile-project-defines will never be overwritten

--- a/template-for-repository/sources/README.md
+++ b/template-for-repository/sources/README.md
@@ -1,6 +1,6 @@
 CBMC proof source code
 ======================
 
-This directory contains source code written for CBMC proof.  It is
+This directory contains source code written for CBMC proofs.  It is
 common to write some code to model aspects of the system under test,
 and this code goes here.


### PR DESCRIPTION
This commit:

- Adds the $(HELPER_DIR) variable, set to the parent of the 'proofs'
  directory, to Makefile.common
- Renames the "sources" directory to "models", so that it doesn't get
  confused with $(SRCDIR)
- Adds the $(MODELS_DIR) and $(STUBS_DIR) variables for easy reference
  from proof makefiles
- Adds a recommendation that project owners should set $(INCLUDES) to
  contain "-I$(HELPER_DIR)/include". This commit does not actually set
  this variable, since the decision of which order it comes in in the
  include list is a matter of project policy.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
