### PR TITLE
Make $(PROOF_SOURCES) always include the harness

### DIFF
--- a/template-for-repository/proofs/Makefile.common
+++ b/template-for-repository/proofs/Makefile.common
@@ -194,9 +194,10 @@ PROJECT_SOURCES ?=
 
 # The proof source files (Normally set in the proof Makefile)
 #
-# PROOF_SOURCES is the list of proof source files to compile, including
-# the proof harness, and including any function stubs being used.
-PROOF_SOURCES ?=
+# PROOF_SOURCES is the list of proof source files to compile. It is at
+# least the proof harness; individual proof Makefiles can add extra
+# proof files, typically from under the $(MODELS_DIR) directory.
+PROOF_SOURCES += $(HARNESS_FILE)
 
 ################################################################
 ################################################################


### PR DESCRIPTION
It will always include the harness, so there's no need to make the user
write it. This commit makes that change and adds advice on adding
additional code from $(MODELS_DIR).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
