### PR TITLE
Copy rather than symlink user-modifiable files

### DIFF
--- a/template-for-repository/proofs/Makefile-project-testing
+++ b/template-for-repository/proofs/Makefile-project-testing
@@ -9,26 +9,3 @@
 # unit testing or continuous integration that may depend on targets
 # defined in Makefile.common
 ################################################################
-
-################################################################
-# Generate cbmc-batch.yaml to run cbmc in continuous integration
-
-JOB_OS ?= ubuntu16
-JOB_MEMORY ?= 32000
-
-define yaml_encode_options
-       "$(shell echo $(1) | sed 's/ ,/ /g' | sed 's/ /;/g')"
-endef
-
-cbmc-batch.yaml:
-	@$(RM) $@
-	@echo 'build_memory: $(JOB_MEMORY)' > $@
-	@echo 'cbmcflags: $(strip $(call yaml_encode_options,$(CBMCFLAGS)))' >> $@
-	@echo 'coverage_memory: $(JOB_MEMORY)' >> $@
-	@echo "expected: SUCCESSFUL" >> $@
-	@echo "goto: $(HARNESS_GOTO).goto" >> $@
-	@echo "jobos: $(JOB_OS)" >> $@
-	@echo 'property_memory: $(JOB_MEMORY)' >> $@
-	@echo 'report_memory: $(JOB_MEMORY)' >> $@
-
-.PHONY: cbmc-batch.yaml

--- a/template-for-repository/proofs/Makefile.common
+++ b/template-for-repository/proofs/Makefile.common
@@ -404,6 +404,31 @@ veryclean: clean
 
 ################################################################
 
+# Rule for generating cbmc-batch.yaml, used by the CI at
+# https://github.com/awslabs/aws-batch-cbmc/
+
+JOB_OS ?= ubuntu16
+JOB_MEMORY ?= 32000
+
+define yaml_encode_options
+       "$(shell echo $(1) | sed 's/ ,/ /g' | sed 's/ /;/g')"
+endef
+
+cbmc-batch.yaml:
+       @$(RM) $@
+       @echo 'build_memory: $(JOB_MEMORY)' > $@
+       @echo 'cbmcflags: $(strip $(call yaml_encode_options,$(CBMCFLAGS)))' >> $@
+       @echo 'coverage_memory: $(JOB_MEMORY)' >> $@
+       @echo "expected: SUCCESSFUL" >> $@
+       @echo "goto: $(HARNESS_GOTO).goto" >> $@
+       @echo "jobos: $(JOB_OS)" >> $@
+       @echo 'property_memory: $(JOB_MEMORY)' >> $@
+       @echo 'report_memory: $(JOB_MEMORY)' >> $@
+
+.PHONY: cbmc-batch.yaml
+
+################################################################
+
 # Project-specific targets requiring values defined above
 sinclude $(PROOF_ROOT)/Makefile-project-targets
 


### PR DESCRIPTION
This commit makes the setup script copy the following files into the
project repository, rather than symbolically linking them:

  * Makefile-project-defines
  * Makefile-project-targets
  * Makefile-project-testing

This is because project owners are expected to modify these files in the
project repository. These changes should not be written to the
submodule, because the submodule would then become dirty and impossible
to update.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
