### PR TITLE
Add a .gitignore to the proof directory

### DIFF
--- a/scripts/util.py
+++ b/scripts/util.py
@@ -20,6 +20,7 @@ COPY_INSTEAD = [
     "Makefile-project-defines",
     "Makefile-project-targets",
     "Makefile-project-testing",
+    ".gitignore",
 ]
 
 ################################################################

--- a/template-for-repository/.gitignore
+++ b/template-for-repository/.gitignore
@@ -1,0 +1,8 @@
+# Emitted when running CBMC proofs
+proofs/**/logs
+proofs/**/gotos
+proofs/**/report
+proofs/**/html
+
+# Emitted by CBMC Viewer
+TAGS-*


### PR DESCRIPTION
The common Makefile writes temporary files into the `gotos`, `logs`,
`html`, and `report` subdirectories of each proof directory by default.
This commit adds a .gitignore to be symlinked into the top-level proof
directory that ignores the contents of these directories, as
proof-writers will almost certainly want to have this file anyway.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
