### PR TITLE
Do not remove function bodies during nondet-static

### DIFF
--- a/template-for-repository/proofs/Makefile.common
+++ b/template-for-repository/proofs/Makefile.common
@@ -321,7 +321,7 @@ $(HARNESS_GOTO)2.goto: $(HARNESS_GOTO)1.goto
 ifeq ($(NONDET_STATIC),"")
 	$(call DO_NOOP_COPY,"Not applying --nondet-static",$<,$@)
 else
-	$(call DO_GOTO_INSTRUMENT,$(CBMC_REMOVE_FUNCTION_BODY) $(NONDET_STATIC),$<,$@)
+	$(call DO_GOTO_INSTRUMENT,$(NONDET_STATIC),$<,$@)
 endif
 
 # Omit unused functions (sharpens coverage calculations)


### PR DESCRIPTION
Prior to this commit, the common Makefile was removing function bodies
during the nondet-static pass. This is incorrect, because function
bodies should only be removed from the project object files, whereas the
nondet-static pass is applied to the linked binary (that contains the
proof stubs that stub out the removed functions). The remove-function
pass has already been applied earlier to the project binary, so it
should not be applied again to the linked binary.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
