### PR TITLE
Make all 3 CBMC jobs run in parallel

### DIFF
--- a/template-for-repository/proofs/Makefile.common
+++ b/template-for-repository/proofs/Makefile.common
@@ -65,6 +65,9 @@ SHELL=/bin/bash
 
 default: report
 
+# Run all CBMC jobs in parallel for a particular proof
+MAKEFLAGS += -j4
+
 ################################################################
 ################################################################
 ## Section I: This section gives common variable definitions.


### PR DESCRIPTION
This commit adds the `-j4` flag to the list of command line arguments
to Make, so that all three runs of CBMC can run in parallel on a
particular proof.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
