### PR TITLE
Ignore cbmc-batch.yaml files

### DIFF
--- a/template-for-repository/.gitignore
+++ b/template-for-repository/.gitignore
@@ -6,3 +6,6 @@ proofs/**/html
 
 # Emitted by CBMC Viewer
 TAGS-*
+
+# These files should be overwritten whenever prepare.py runs
+cbmc-batch.yaml


### PR DESCRIPTION
These files are generated by prepare.py and should be ignored.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
