### PR TITLE
Use short form of Apache license.

### DIFF
--- a/template-for-repository/proofs/prepare.py
+++ b/template-for-repository/proofs/prepare.py
@@ -3,13 +3,17 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+
 """Prepare the source tree for proofs in continuous integration."""
+
 
 import os
 import subprocess
 
+
 MAKEFILE = "Makefile"
 CBMC_BATCH_YAML = "cbmc-batch.yaml"
+
 
 def create_cbmc_batch_yaml(folder):
     """Run make to create cbmc-batch.yaml in folder."""
@@ -31,6 +35,7 @@ def create_cbmc_batch_yaml(folder):
                                   ' '.join(error.cmd),
                                   error.stderr.strip())) from None
 
+
 def create_cbmc_batch_yaml_files(root='.'):
     """Create cbmc-batch.yaml in all directories under root."""
 
@@ -38,10 +43,12 @@ def create_cbmc_batch_yaml_files(root='.'):
         if CBMC_BATCH_YAML in files and MAKEFILE in files:
             create_cbmc_batch_yaml(folder)
 
+
 def prepare():
     """Prepare the source tree for proofs in continuous integration."""
 
     create_cbmc_batch_yaml_files()
+
 
 if __name__ == "__main__":
     prepare()

--- a/template-for-repository/proofs/prepare.py
+++ b/template-for-repository/proofs/prepare.py
@@ -1,29 +1,15 @@
 #!/usr/bin/env python3
-#
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"). You may not
-# use this file except in compliance with the License. A copy of the License is
-# located at
-#
-#     http://aws.amazon.com/apache2.0/
-#
-# or in the "license" file accompanying this file. This file is distributed on
-# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
-# or implied. See the License for the specific language governing permissions
-# and limitations under the License.
 
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 """Prepare the source tree for proofs in continuous integration."""
-
 
 import os
 import subprocess
 
-
 MAKEFILE = "Makefile"
 CBMC_BATCH_YAML = "cbmc-batch.yaml"
-
 
 def create_cbmc_batch_yaml(folder):
     """Run make to create cbmc-batch.yaml in folder."""
@@ -45,7 +31,6 @@ def create_cbmc_batch_yaml(folder):
                                   ' '.join(error.cmd),
                                   error.stderr.strip())) from None
 
-
 def create_cbmc_batch_yaml_files(root='.'):
     """Create cbmc-batch.yaml in all directories under root."""
 
@@ -53,12 +38,10 @@ def create_cbmc_batch_yaml_files(root='.'):
         if CBMC_BATCH_YAML in files and MAKEFILE in files:
             create_cbmc_batch_yaml(folder)
 
-
 def prepare():
     """Prepare the source tree for proofs in continuous integration."""
 
     create_cbmc_batch_yaml_files()
-
 
 if __name__ == "__main__":
     prepare()


### PR DESCRIPTION
Use short form of Apache license in prepare.py to be consistent with other files in the repository, and remove double spacing from prepare.py.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
