### PR TITLE
Fix punctuation in proof README.md

### DIFF
--- a/template-for-proof/README.md
+++ b/template-for-proof/README.md
@@ -5,6 +5,6 @@ This directory contains a memory safety proof for <__FUNCTION_NAME__>.
 
 To run the proof.
 * Add cbmc, goto-cc, goto-instrument, goto-analyzer, and cbmc-viewer
-  to your path
-* Run "make"
+  to your path.
+* Run "make".
 * Open html/index.html in a web browser.


### PR DESCRIPTION
Fix punctuation in README.md as requested by a service team.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
