### PR TITLE
Patch --unwindset in Makefile.common.

### DIFF
--- a/template-for-repository/proofs/Makefile.common
+++ b/template-for-repository/proofs/Makefile.common
@@ -287,7 +287,11 @@ DEFINES += -DCBMC=1
 DEFINES += -DCBMC_OBJECT_BITS=$(CBMC_OBJECT_BITS)
 DEFINES += -DCBMC_MAX_OBJECT_SIZE="(SIZE_MAX>>(CBMC_OBJECT_BITS+1))"
 
-CBMC_UNWINDSET := $(patsubst %,--unwindset %, $(UNWINDSET))
+# CI currently assumes cbmc invocation has at most one --unwindset
+# CBMC_UNWINDSET := $(patsubst %,--unwindset %, $(UNWINDSET))
+ifneq ($(UNWINDSET),"")
+  CBMC_UNWINDSET = --unwindset $(subst $(SPACE),$(COMMA),$(strip $(UNWINDSET)))
+endif
 CBMC_REMOVE_FUNCTION_BODY := $(patsubst %,--remove-function-body %, $(REMOVE_FUNCTION_BODY))
 
 ################################################################

--- a/template-for-repository/proofs/Makefile.common
+++ b/template-for-repository/proofs/Makefile.common
@@ -288,9 +288,8 @@ DEFINES += -DCBMC_OBJECT_BITS=$(CBMC_OBJECT_BITS)
 DEFINES += -DCBMC_MAX_OBJECT_SIZE="(SIZE_MAX>>(CBMC_OBJECT_BITS+1))"
 
 # CI currently assumes cbmc invocation has at most one --unwindset
-# CBMC_UNWINDSET := $(patsubst %,--unwindset %, $(UNWINDSET))
 ifneq ($(UNWINDSET),"")
-  CBMC_UNWINDSET = --unwindset $(subst $(SPACE),$(COMMA),$(strip $(UNWINDSET)))
+  CBMC_UNWINDSET := --unwindset $(subst $(SPACE),$(COMMA),$(strip $(UNWINDSET)))
 endif
 CBMC_REMOVE_FUNCTION_BODY := $(patsubst %,--remove-function-body %, $(REMOVE_FUNCTION_BODY))
 


### PR DESCRIPTION
Continuous integration currently assumes the cbmc invocation has at most one instance of --unwindset on the command line.  This patches Makefile.common to join multiple invocations into one until CI is updated.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
