### PR TITLE
Don't pass --unwindset when UNWINDSET not defined

### DIFF
--- a/template-for-repository/proofs/Makefile.common
+++ b/template-for-repository/proofs/Makefile.common
@@ -288,8 +288,10 @@ DEFINES += -DCBMC_OBJECT_BITS=$(CBMC_OBJECT_BITS)
 DEFINES += -DCBMC_MAX_OBJECT_SIZE="(SIZE_MAX>>(CBMC_OBJECT_BITS+1))"
 
 # CI currently assumes cbmc invocation has at most one --unwindset
-ifneq ($(UNWINDSET),"")
-  CBMC_UNWINDSET := --unwindset $(subst $(SPACE),$(COMMA),$(strip $(UNWINDSET)))
+ifdef UNWINDSET
+  ifneq ($(strip $(UNWINDSET)),"")
+    CBMC_UNWINDSET := --unwindset $(subst $(SPACE),$(COMMA),$(strip $(UNWINDSET)))
+  endif
 endif
 CBMC_REMOVE_FUNCTION_BODY := $(patsubst %,--remove-function-body %, $(REMOVE_FUNCTION_BODY))
 


### PR DESCRIPTION
This commit fixes the expansion of $CBMC_UNWINDSET. Previously, the
expansion of $CBMC_UNWINDSET had assumed that the $UNWINDSET variable
was defined but empty. However, this variable is not actually defined in
Makefile.common, not should it be.

This commit expands the --unwindset flag only if the $UNWINDSET variable
is both defined and empty.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
