### PR TITLE
Convert starter kit to use Litani

### DIFF
--- a/template-for-repository/proofs/Makefile-project-defines
+++ b/template-for-repository/proofs/Makefile-project-defines
@@ -13,6 +13,9 @@
 # Makefile.common.
 ################################################################
 
+# Path to litani executable
+# LITANI =
+
 # Flags to pass to goto-cc for compilation (typically those passed to gcc -c)
 # COMPILE_FLAGS =
 

--- a/template-for-repository/proofs/Makefile-project-defines
+++ b/template-for-repository/proofs/Makefile-project-defines
@@ -13,6 +13,9 @@
 # Makefile.common.
 ################################################################
 
+# Name of this proof project, displayed in proof reports
+# PROJECT_NAME =
+
 # Path to litani executable
 # LITANI =
 

--- a/template-for-repository/proofs/Makefile-project-defines
+++ b/template-for-repository/proofs/Makefile-project-defines
@@ -13,10 +13,16 @@
 # Makefile.common.
 ################################################################
 
-# Name of this proof project, displayed in proof reports
+# Name of this proof project, displayed in proof reports. For example,
+# "s2n" or "Amazon FreeRTOS". For projects with multiple proof roots,
+# this may be overridden on the command-line to Make, for example
+#
+# 	  make PROJECT_NAME="FreeRTOS MQTT" report
+#
 # PROJECT_NAME =
 
-# Path to litani executable
+# Path to litani executable, relative to the root of the repository.
+# This applies even for projects with multiple proof roots.
 # LITANI =
 
 # Flags to pass to goto-cc for compilation (typically those passed to gcc -c)

--- a/template-for-repository/proofs/Makefile.common
+++ b/template-for-repository/proofs/Makefile.common
@@ -244,33 +244,6 @@ SPACE :=$() $()
 COMMA :=,
 
 ################################################################
-# Useful macros for running commands
-
-#1: command, 2: flags, 3: log file
-DO_AND_LOG_COMMAND = $(1) $(2) 2>&1 | tee $(3); exit $${PIPESTATUS[0]}
-
-#1: command, 2: flags, 3: log file
-
-# CBMC uses the special error-code 10 to signify that it detected an
-# assertion violation.	Continue the build so we can output the trace.
-DO_AND_LOG_IGNORING_ERROR_10 =	$(1) $(2) 2>&1 | tee $(3); if [ $${PIPESTATUS[0]} -ne 10 ]; then exit $${PIPESTATUS[0]}; fi
-
-#1: flags, 2: source, 3: target
-DO_GOTO_ANALYZER = $(call DO_AND_LOG_COMMAND,$(GOTO_ANALYZER),$(CBMC_VERBOSITY) $(1) $(2) $(3), $(call LOG_FROM_ENTRY,$(3)))
-
-#1: flags, 2: source, 3: target
-DO_GOTO_CC =  $(call DO_AND_LOG_COMMAND,$(GOTO_CC),$(CBMC_VERBOSITY) $(1) $(2) -o $(3), $(call LOG_FROM_ENTRY,$(3)))
-
-#1: flags, 2: source, 3: target
-DO_GOTO_INSTRUMENT = $(call DO_AND_LOG_COMMAND,$(GOTO_INSTRUMENT),$(CBMC_VERBOSITY) $(1) $(2) $(3), $(call LOG_FROM_ENTRY,$(3)))
-
-#1: flags, 2: source, 3: logfile
-DO_CBMC =  $(call DO_AND_LOG_IGNORING_ERROR_10,$(CBMC),$(CBMC_VERBOSITY) --flush $(1) $(2), $(3))
-
-#1: message 2: source 3: dest
-DO_NOOP_COPY = cp $(2) $(3); echo $(1) | tee $(call LOG_FROM_ENTRY,$(3))
-
-################################################################
 # Useful macros translating filenames
 
 C_FROM_GOTO = $(patsubst $(GOTODIR)%,$(SRCDIR)%,$(1:.goto=.c))

--- a/template-for-repository/proofs/Makefile.common
+++ b/template-for-repository/proofs/Makefile.common
@@ -300,51 +300,129 @@ CBMC_REMOVE_FUNCTION_BODY := $(patsubst %,--remove-function-body %, $(REMOVE_FUN
 
 # Compile project sources
 $(PROJECT_GOTO)1.goto: $(PROJECT_SOURCES)
-	mkdir -p $(dir $@)
-	mkdir -p $(dir $(call LOG_FROM_ENTRY,$@))
-	$(call DO_GOTO_CC,--export-file-local-symbols $(COMPILE_FLAGS) $(INCLUDES) $(DEFINES),$^,$@)
+	$(LITANI) add-job \
+	  --command \
+	    '$(GOTO_CC) $(CBMC_VERBOSITY) --export-file-local-symbols $(COMPILE_FLAGS) $(INCLUDES) $(DEFINES) $^ -o $@' \
+	  --inputs $^ \
+	  --outputs $@ $(call LOG_FROM_ENTRY,$@) \
+	  --pipeline-name $(HARNESS_ENTRY) \
+	  --ci-stage build \
+	  --interleave-stdout-stderr \
+	  --stdout-file $(call LOG_FROM_ENTRY,$@) \
+	  --description "$(HARNESS_ENTRY): building project binary"
 
 # Compile proof sources
 $(PROOF_GOTO)1.goto: $(PROOF_SOURCES)
-	mkdir -p $(dir $@)
-	mkdir -p $(dir $(call LOG_FROM_ENTRY,$@))
-	$(call DO_GOTO_CC,--export-file-local-symbols $(COMPILE_FLAGS) $(INCLUDES) $(DEFINES),$^,$@)
+	$(LITANI) add-job \
+	  --command \
+	    '$(GOTO_CC) $(CBMC_VERBOSITY) --export-file-local-symbols $(COMPILE_FLAGS) $(INCLUDES) $(DEFINES) $^ -o $@' \
+	  --inputs $^ \
+	  --outputs $@ $(call LOG_FROM_ENTRY,$@) \
+	  --pipeline-name $(HARNESS_ENTRY) \
+	  --ci-stage build \
+	  --interleave-stdout-stderr \
+	  --stdout-file $(call LOG_FROM_ENTRY,$@) \
+	  --description "$(HARNESS_ENTRY): building proof binary"
 
 # Optionally remove function bodies from project sources
 $(PROJECT_GOTO)2.goto: $(PROJECT_GOTO)1.goto
 ifeq ($(REMOVE_FUNCTION_BODY),"")
-	$(call DO_NOOP_COPY,"Not removing function bodies",$<,$@)
+	$(LITANI) add-job \
+	  --command 'cp $^ $@' \
+	  --inputs $^ \
+	  --outputs $@ $(call LOG_FROM_ENTRY,$@)\
+	  --pipeline-name $(HARNESS_ENTRY) \
+	  --ci-stage build \
+	  --interleave-stdout-stderr \
+	  --stdout-file $(call LOG_FROM_ENTRY,$@) \
+	  --description "$(HARNESS_ENTRY): not removing function bodies"
 else
-	$(call DO_GOTO_INSTRUMENT,$(CBMC_REMOVE_FUNCTION_BODY),$<,$@)
+	$(LITANI) add-job \
+	  --command \
+	    '$(GOTO_INSTRUMENT) $(CBMC_VERBOSITY) $(CBMC_REMOVE_FUNCTION_BODY) $^ $@' \
+	  --inputs $^ \
+	  --outputs $@ $(call LOG_FROM_ENTRY,$@) \
+	  --pipeline-name $(HARNESS_ENTRY) \
+	  --ci-stage build \
+	  --interleave-stdout-stderr \
+	  --stdout-file $(call LOG_FROM_ENTRY,$@) \
+	  --description "$(HARNESS_ENTRY): removing function bodies"
 endif
 
-# Don't remove function bodies from proof sources
-$(PROOF_GOTO)2.goto: $(PROOF_GOTO)1.goto
-	$(call DO_NOOP_COPY,"Not removing function bodies",$<,$@)
-
 # Link project and proof sources into the proof harness
-$(HARNESS_GOTO)1.goto: $(PROOF_GOTO)2.goto $(PROJECT_GOTO)2.goto
-	$(call DO_GOTO_CC,--function $(HARNESS_ENTRY),$^,$@)
+$(HARNESS_GOTO)1.goto: $(PROOF_GOTO)1.goto $(PROJECT_GOTO)2.goto
+	$(LITANI) add-job \
+	  --command '$(GOTO_CC) --function $(HARNESS_ENTRY) $^ -o $@' \
+	  --inputs $^ \
+	  --outputs $@ $(call LOG_FROM_ENTRY,$@) \
+	  --pipeline-name $(HARNESS_ENTRY) \
+	  --ci-stage build \
+	  --interleave-stdout-stderr \
+	  --stdout-file $(call LOG_FROM_ENTRY,$@) \
+	  --description "$(HARNESS_ENTRY): linking project to proof"
 
 # Optionally fill static variable with unconstrained values
 $(HARNESS_GOTO)2.goto: $(HARNESS_GOTO)1.goto
 ifeq ($(NONDET_STATIC),"")
-	$(call DO_NOOP_COPY,"Not applying --nondet-static",$<,$@)
+	$(LITANI) add-job \
+	  --command 'cp $^ $@' \
+	  --inputs $^ \
+	  --outputs $@ $(call LOG_FROM_ENTRY,$@)\
+	  --pipeline-name $(HARNESS_ENTRY) \
+	  --ci-stage build \
+	  --interleave-stdout-stderr \
+	  --stdout-file $(call LOG_FROM_ENTRY,$@) \
+	  --description "$(HARNESS_ENTRY): not setting static variables to nondet"
 else
-	$(call DO_GOTO_INSTRUMENT,$(NONDET_STATIC),$<,$@)
+	$(LITANI) add-job \
+	  --command \
+	    '$(GOTO_INSTRUMENT) $(CBMC_VERBOSITY) $(NONDET_STATIC) $^ $@' \
+	  --inputs $^ \
+	  --outputs $@ $(call LOG_FROM_ENTRY,$@) \
+	  --pipeline-name $(HARNESS_ENTRY) \
+	  --ci-stage build \
+	  --interleave-stdout-stderr \
+	  --stdout-file $(call LOG_FROM_ENTRY,$@) \
+	  --description "$(HARNESS_ENTRY): setting static variables to nondet"
 endif
 
 # Omit unused functions (sharpens coverage calculations)
 $(HARNESS_GOTO)3.goto: $(HARNESS_GOTO)2.goto
-	$(call DO_GOTO_INSTRUMENT,--drop-unused-functions,$<,$@)
+	$(LITANI) add-job \
+	  --command \
+	    '$(GOTO_INSTRUMENT) $(CBMC_VERBOSITY) --drop-unused-functions $^ $@' \
+	  --inputs $^ \
+	  --outputs $@ $(call LOG_FROM_ENTRY,$@) \
+	  --pipeline-name $(HARNESS_ENTRY) \
+	  --ci-stage build \
+	  --interleave-stdout-stderr \
+	  --stdout-file $(call LOG_FROM_ENTRY,$@) \
+	  --description "$(HARNESS_ENTRY): dropping unused functions"
 
 # Omit initialization of unused global variables (reduces problem size)
 $(HARNESS_GOTO)4.goto: $(HARNESS_GOTO)3.goto
-	$(call DO_GOTO_INSTRUMENT,--slice-global-inits,$<,$@)
+	$(LITANI) add-job \
+	  --command \
+	    '$(GOTO_INSTRUMENT) $(CBMC_VERBOSITY) --slice-global-inits $^ $@' \
+	  --inputs $^ \
+	  --outputs $@ $(call LOG_FROM_ENTRY,$@) \
+	  --pipeline-name $(HARNESS_ENTRY) \
+	  --ci-stage build \
+	  --interleave-stdout-stderr \
+	  --stdout-file $(call LOG_FROM_ENTRY,$@) \
+	  --description "$(HARNESS_ENTRY): omitting unused global initializations"
 
 # Final name for proof harness
 $(HARNESS_GOTO).goto: $(HARNESS_GOTO)4.goto
-	cp $< $@
+	$(LITANI) add-job \
+	  --command 'cp $< $@' \
+	  --inputs $^ \
+	  --outputs $@ $(call LOG_FROM_ENTRY,$@)\
+	  --pipeline-name $(HARNESS_ENTRY) \
+	  --ci-stage build \
+	  --interleave-stdout-stderr \
+	  --stdout-file $(call LOG_FROM_ENTRY,$@) \
+	  --description "$(HARNESS_ENTRY): copying final goto-binary"
 
 goto: $(HARNESS_GOTO).goto
 	echo $(DEPENDENT_GOTOS)
@@ -365,16 +443,55 @@ arpa: $(ARPA_BLDDIR)
 # Targets to run the analysis commands
 
 $(LOGDIR)/result.txt: $(HARNESS_GOTO).goto
-	$(call DO_CBMC,$(CBMCFLAGS) $(CHECKFLAGS) --unwinding-assertions --trace,$<,$@)
+	$(LITANI) add-job \
+	  --command \
+	    '$(CBMC) $(CBMC_VERBOSITY) --flush $(CBMCFLAGS) $(CHECKFLAGS) --unwinding-assertions --trace $<' \
+	  --inputs $^ \
+	  --outputs $@ \
+	  --pipeline-name $(HARNESS_ENTRY) \
+	  --ci-stage test \
+	  --stdout-file $@ \
+	  --ignore-returns 10 \
+	  --tags "stats-group:safety checks" \
+	  --description "$(HARNESS_ENTRY): checking safety properties"
 
 $(LOGDIR)/result.xml: $(HARNESS_GOTO).goto
-	$(call DO_CBMC,$(CBMCFLAGS) $(CHECKFLAGS) --unwinding-assertions --trace --xml-ui,$<,$@)
+	$(LITANI) add-job \
+	  --command \
+	    '$(CBMC) $(CBMC_VERBOSITY) --flush $(CBMCFLAGS) $(CHECKFLAGS) --unwinding-assertions --trace --xml-ui $<' \
+	  --inputs $^ \
+	  --outputs $@ \
+	  --pipeline-name $(HARNESS_ENTRY) \
+	  --ci-stage test \
+	  --stdout-file $@ \
+	  --ignore-returns 10 \
+	  --tags "stats-group:safety checks" \
+	  --description "$(HARNESS_ENTRY): checking safety properties"
 
 $(LOGDIR)/property.xml: $(HARNESS_GOTO).goto
-	$(call DO_CBMC,$(CBMCFLAGS) $(CHECKFLAGS) --unwinding-assertions --show-properties --xml-ui,$<,$@)
+	$(LITANI) add-job \
+	  --command \
+	    '$(CBMC) $(CBMC_VERBOSITY) --flush $(CBMCFLAGS) $(CHECKFLAGS) --show-properties --xml-ui $<' \
+	  --inputs $^ \
+	  --outputs $@ \
+	  --pipeline-name $(HARNESS_ENTRY) \
+	  --ci-stage test \
+	  --stdout-file $@ \
+	  --ignore-returns 10 \
+	  --description "$(HARNESS_ENTRY): printing safety properties"
 
 $(LOGDIR)/coverage.xml: $(HARNESS_GOTO).goto
-	$(call DO_CBMC,$(CBMCFLAGS) $(COVERFLAGS) --cover location --xml-ui,$<,$@)
+	$(LITANI) add-job \
+	  --command \
+	    '$(CBMC) $(CBMC_VERBOSITY) --flush $(CBMCFLAGS) $(COVERFLAGS) --cover location --xml-ui $<' \
+	  --inputs $^ \
+	  --outputs $@ \
+	  --pipeline-name $(HARNESS_ENTRY) \
+	  --ci-stage test \
+	  --stdout-file $@ \
+	  --ignore-returns 10 \
+	  --tags "stats-group:coverage computation" \
+	  --description "$(HARNESS_ENTRY): calculating coverage"
 
 result: $(LOGDIR)/result.txt
 
@@ -382,14 +499,32 @@ property: $(LOGDIR)/property.xml
 
 coverage: $(LOGDIR)/coverage.xml
 
+define VIEWER_CMD
+  $(VIEWER) \
+    --result $(LOGDIR)/result.txt \
+    --block $(LOGDIR)/coverage.xml \
+    --property $(LOGDIR)/property.xml \
+    --srcdir $(SRCDIR) \
+    --goto $(HARNESS_GOTO).goto \
+    --htmldir $(PROOFDIR)/html
+endef
+export VIEWER_CMD
+
 report: $(LOGDIR)/result.txt $(LOGDIR)/property.xml $(LOGDIR)/coverage.xml
-	$(VIEWER) \
-	--result $(LOGDIR)/result.txt \
-	--block $(LOGDIR)/coverage.xml \
-	--property $(LOGDIR)/property.xml \
-	--srcdir $(SRCDIR) \
-	--goto $(HARNESS_GOTO).goto \
-	--htmldir html \
+	$(LITANI) add-job \
+	  --command "$$VIEWER_CMD" \
+	  --inputs $^ \
+	  --outputs $(PROOFDIR)/html \
+	  --pipeline-name $(HARNESS_ENTRY) \
+	  --ci-stage report \
+	  --tags "stats-group:report generation" \
+	  --interleave-stdout-stderr \
+	  --description "$(HARNESS_ENTRY): generating report"
+
+report:
+	$(LITANI) init --project $(PROJECT_NAME)
+	$(MAKE) -B _report
+	$(LITANI) run-build
 
 # Caution: run make-source before running property and coverage checking
 # The current make-source script removes the goto binary
@@ -399,17 +534,37 @@ $(LOGDIR)/source.json:
 	$(MAKE_SOURCE) --srcdir $(SRCDIR) --wkdir $(PROOFDIR) > $@
 	$(RM) -r $(GOTODIR)
 
+define VIEWER2_CMD
+  $(VIEWER2) \
+    --result $(LOGDIR)/result.xml \
+    --coverage $(LOGDIR)/coverage.xml \
+    --property $(LOGDIR)/property.xml \
+    --srcdir $(SRCDIR) \
+    --goto $(HARNESS_GOTO).goto \
+    --reportdir $(PROOFDIR)/report
+endef
+export VIEWER2_CMD
+
 # Omit logs/source.json from report generation until make-sources
 # works correctly with Makefiles that invoke the compiler with
 # mutliple source files at once.
 report2: $(LOGDIR)/result.xml $(LOGDIR)/property.xml $(LOGDIR)/coverage.xml
-	$(VIEWER2) \
-	--result $(LOGDIR)/result.xml \
-	--coverage $(LOGDIR)/coverage.xml \
-	--property $(LOGDIR)/property.xml \
-	--srcdir $(SRCDIR) \
-	--goto $(HARNESS_GOTO).goto \
-	--reportdir report \
+	$(LITANI) add-job \
+	  --command "$$VIEWER2_CMD" \
+	  --inputs $^ \
+	  --outputs $(PROOFDIR)/report \
+	  --pipeline-name $(HARNESS_ENTRY) \
+	  --ci-stage report \
+	  --tags "stats-group:report generation" \
+	  --description "$(HARNESS_ENTRY): generating report"
+
+report2:
+	$(LITANI) init --project $(PROJECT_NAME)
+	$(MAKE) -B _report2
+	$(LITANI) run-build
+
+litani-path:
+	@echo $(LITANI)
 
 ################################################################
 # Targets to clean up after ourselves

--- a/template-for-repository/proofs/Makefile.common
+++ b/template-for-repository/proofs/Makefile.common
@@ -424,8 +424,14 @@ $(HARNESS_GOTO).goto: $(HARNESS_GOTO)4.goto
 	  --stdout-file $(call LOG_FROM_ENTRY,$@) \
 	  --description "$(HARNESS_ENTRY): copying final goto-binary"
 
-goto: $(HARNESS_GOTO).goto
+
+_goto: $(HARNESS_GOTO).goto
 	echo $(DEPENDENT_GOTOS)
+goto:
+	$(LITANI) init --project $(PROJECT_NAME)
+	$(MAKE) -B _goto
+	$(LITANI) run-build
+
 
 ################################################################
 # Targets to run Arpa
@@ -493,11 +499,24 @@ $(LOGDIR)/coverage.xml: $(HARNESS_GOTO).goto
 	  --tags "stats-group:coverage computation" \
 	  --description "$(HARNESS_ENTRY): calculating coverage"
 
-result: $(LOGDIR)/result.txt
+_result: $(LOGDIR)/result.txt
+result:
+	$(LITANI) init --project $(PROJECT_NAME)
+	$(MAKE) -B _result
+	$(LITANI) run-build
 
-property: $(LOGDIR)/property.xml
 
-coverage: $(LOGDIR)/coverage.xml
+_property: $(LOGDIR)/property.xml
+property:
+	$(LITANI) init --project $(PROJECT_NAME)
+	$(MAKE) -B _property
+	$(LITANI) run-build
+
+_coverage: $(LOGDIR)/coverage.xml
+coverage:
+	$(LITANI) init --project $(PROJECT_NAME)
+	$(MAKE) -B _coverage
+	$(LITANI) run-build
 
 define VIEWER_CMD
   $(VIEWER) \
@@ -510,7 +529,7 @@ define VIEWER_CMD
 endef
 export VIEWER_CMD
 
-report: $(LOGDIR)/result.txt $(LOGDIR)/property.xml $(LOGDIR)/coverage.xml
+_report: $(LOGDIR)/result.txt $(LOGDIR)/property.xml $(LOGDIR)/coverage.xml
 	$(LITANI) add-job \
 	  --command "$$VIEWER_CMD" \
 	  --inputs $^ \
@@ -520,6 +539,10 @@ report: $(LOGDIR)/result.txt $(LOGDIR)/property.xml $(LOGDIR)/coverage.xml
 	  --tags "stats-group:report generation" \
 	  --interleave-stdout-stderr \
 	  --description "$(HARNESS_ENTRY): generating report"
+report:
+	$(LITANI) init --project $(PROJECT_NAME)
+	$(MAKE) -B _report
+	$(LITANI) run-build
 
 report:
 	$(LITANI) init --project $(PROJECT_NAME)
@@ -548,7 +571,7 @@ export VIEWER2_CMD
 # Omit logs/source.json from report generation until make-sources
 # works correctly with Makefiles that invoke the compiler with
 # mutliple source files at once.
-report2: $(LOGDIR)/result.xml $(LOGDIR)/property.xml $(LOGDIR)/coverage.xml
+_report2: $(LOGDIR)/result.xml $(LOGDIR)/property.xml $(LOGDIR)/coverage.xml
 	$(LITANI) add-job \
 	  --command "$$VIEWER2_CMD" \
 	  --inputs $^ \
@@ -557,6 +580,10 @@ report2: $(LOGDIR)/result.xml $(LOGDIR)/property.xml $(LOGDIR)/coverage.xml
 	  --ci-stage report \
 	  --tags "stats-group:report generation" \
 	  --description "$(HARNESS_ENTRY): generating report"
+report2:
+	$(LITANI) init --project $(PROJECT_NAME)
+	$(MAKE) -B _report2
+	$(LITANI) run-build
 
 report2:
 	$(LITANI) init --project $(PROJECT_NAME)
@@ -579,8 +606,26 @@ veryclean: clean
 	-$(RM) -r html report
 	-$(RM) -r $(LOGDIR) $(GOTODIR)
 
-.PHONY: setup_dependencies arpa result property coverage report clean
-.PHONY: veryclean testdeps litani-path
+.PHONY: \
+  arpa \
+  clean \
+  coverage \
+  _coverage \
+  goto \
+  _goto \
+  litani-path \
+  property \
+  _property \
+  report \
+  _report \
+  report2 \
+  _report2 \
+  result \
+  _result \
+  testdeps \
+  veryclean \
+  setup_dependencies \
+  #
 
 ################################################################
 

--- a/template-for-repository/proofs/Makefile.common
+++ b/template-for-repository/proofs/Makefile.common
@@ -281,7 +281,7 @@ LOG_FROM_GOTO = $(patsubst $(GOTODIR)%,$(LOGDIR)%,$(1:.goto=.txt))
 ################################################################
 # Set C compiler defines
 
-CBMCFLAGS +=  --object-bits $(CBMC_OBJECT_BITS)
+CBMCFLAGS += --object-bits $(CBMC_OBJECT_BITS) --flush
 
 DEFINES += -DCBMC=1
 DEFINES += -DCBMC_OBJECT_BITS=$(CBMC_OBJECT_BITS)
@@ -424,7 +424,6 @@ $(HARNESS_GOTO).goto: $(HARNESS_GOTO)4.goto
 	  --stdout-file $(call LOG_FROM_ENTRY,$@) \
 	  --description "$(HARNESS_ENTRY): copying final goto-binary"
 
-
 _goto: $(HARNESS_GOTO).goto
 	echo $(DEPENDENT_GOTOS)
 goto:
@@ -464,7 +463,7 @@ $(LOGDIR)/result.txt: $(HARNESS_GOTO).goto
 $(LOGDIR)/result.xml: $(HARNESS_GOTO).goto
 	$(LITANI) add-job \
 	  --command \
-	    '$(CBMC) $(CBMC_VERBOSITY) --flush $(CBMCFLAGS) $(CHECKFLAGS) --unwinding-assertions --trace --xml-ui $<' \
+	    '$(CBMC) $(CBMC_VERBOSITY) $(CBMCFLAGS) $(CHECKFLAGS) --unwinding-assertions --trace --xml-ui $<' \
 	  --inputs $^ \
 	  --outputs $@ \
 	  --pipeline-name $(HARNESS_ENTRY) \
@@ -477,7 +476,7 @@ $(LOGDIR)/result.xml: $(HARNESS_GOTO).goto
 $(LOGDIR)/property.xml: $(HARNESS_GOTO).goto
 	$(LITANI) add-job \
 	  --command \
-	    '$(CBMC) $(CBMC_VERBOSITY) --flush $(CBMCFLAGS) $(CHECKFLAGS) --show-properties --xml-ui $<' \
+	    '$(CBMC) $(CBMC_VERBOSITY) $(CBMCFLAGS) $(CHECKFLAGS) --show-properties --xml-ui $<' \
 	  --inputs $^ \
 	  --outputs $@ \
 	  --pipeline-name $(HARNESS_ENTRY) \
@@ -489,7 +488,7 @@ $(LOGDIR)/property.xml: $(HARNESS_GOTO).goto
 $(LOGDIR)/coverage.xml: $(HARNESS_GOTO).goto
 	$(LITANI) add-job \
 	  --command \
-	    '$(CBMC) $(CBMC_VERBOSITY) --flush $(CBMCFLAGS) $(COVERFLAGS) --cover location --xml-ui $<' \
+	    '$(CBMC) $(CBMC_VERBOSITY) $(CBMCFLAGS) $(COVERFLAGS) --cover location --xml-ui $<' \
 	  --inputs $^ \
 	  --outputs $@ \
 	  --pipeline-name $(HARNESS_ENTRY) \

--- a/template-for-repository/proofs/Makefile.common
+++ b/template-for-repository/proofs/Makefile.common
@@ -579,7 +579,8 @@ veryclean: clean
 	-$(RM) -r html report
 	-$(RM) -r $(LOGDIR) $(GOTODIR)
 
-.PHONY: setup_dependencies arpa result property coverage report clean veryclean testdeps
+.PHONY: setup_dependencies arpa result property coverage report clean
+.PHONY: veryclean testdeps litani-path
 
 ################################################################
 

--- a/template-for-repository/proofs/Makefile.common
+++ b/template-for-repository/proofs/Makefile.common
@@ -244,14 +244,6 @@ SPACE :=$() $()
 COMMA :=,
 
 ################################################################
-# Useful macros translating filenames
-
-C_FROM_GOTO = $(patsubst $(GOTODIR)%,$(SRCDIR)%,$(1:.goto=.c))
-GOTO_FROM_C = $(patsubst $(SRCDIR)%,$(GOTODIR)%,$(1:.c=.goto))
-LOG_FROM_ENTRY = $(LOGDIR)/$(notdir $(1:.goto=.txt))
-LOG_FROM_GOTO = $(patsubst $(GOTODIR)%,$(LOGDIR)%,$(1:.goto=.txt))
-
-################################################################
 # Set C compiler defines
 
 CBMCFLAGS += --object-bits $(CBMC_OBJECT_BITS) --flush
@@ -277,11 +269,9 @@ $(PROJECT_GOTO)1.goto: $(PROJECT_SOURCES)
 	  --command \
 	    '$(GOTO_CC) $(CBMC_VERBOSITY) --export-file-local-symbols $(COMPILE_FLAGS) $(INCLUDES) $(DEFINES) $^ -o $@' \
 	  --inputs $^ \
-	  --outputs $@ $(call LOG_FROM_ENTRY,$@) \
+	  --outputs $@ \
 	  --pipeline-name $(HARNESS_ENTRY) \
 	  --ci-stage build \
-	  --interleave-stdout-stderr \
-	  --stdout-file $(call LOG_FROM_ENTRY,$@) \
 	  --description "$(HARNESS_ENTRY): building project binary"
 
 # Compile proof sources
@@ -290,11 +280,9 @@ $(PROOF_GOTO)1.goto: $(PROOF_SOURCES)
 	  --command \
 	    '$(GOTO_CC) $(CBMC_VERBOSITY) --export-file-local-symbols $(COMPILE_FLAGS) $(INCLUDES) $(DEFINES) $^ -o $@' \
 	  --inputs $^ \
-	  --outputs $@ $(call LOG_FROM_ENTRY,$@) \
+	  --outputs $@ \
 	  --pipeline-name $(HARNESS_ENTRY) \
 	  --ci-stage build \
-	  --interleave-stdout-stderr \
-	  --stdout-file $(call LOG_FROM_ENTRY,$@) \
 	  --description "$(HARNESS_ENTRY): building proof binary"
 
 # Optionally remove function bodies from project sources
@@ -303,35 +291,29 @@ ifeq ($(REMOVE_FUNCTION_BODY),"")
 	$(LITANI) add-job \
 	  --command 'cp $^ $@' \
 	  --inputs $^ \
-	  --outputs $@ $(call LOG_FROM_ENTRY,$@)\
+	  --outputs $@ \
 	  --pipeline-name $(HARNESS_ENTRY) \
 	  --ci-stage build \
-	  --interleave-stdout-stderr \
-	  --stdout-file $(call LOG_FROM_ENTRY,$@) \
-	  --description "$(HARNESS_ENTRY): not removing function bodies"
+	  --description "$(HARNESS_ENTRY): not removing function bodies from project sources"
 else
 	$(LITANI) add-job \
 	  --command \
 	    '$(GOTO_INSTRUMENT) $(CBMC_VERBOSITY) $(CBMC_REMOVE_FUNCTION_BODY) $^ $@' \
 	  --inputs $^ \
-	  --outputs $@ $(call LOG_FROM_ENTRY,$@) \
+	  --outputs $@ \
 	  --pipeline-name $(HARNESS_ENTRY) \
 	  --ci-stage build \
-	  --interleave-stdout-stderr \
-	  --stdout-file $(call LOG_FROM_ENTRY,$@) \
-	  --description "$(HARNESS_ENTRY): removing function bodies"
+	  --description "$(HARNESS_ENTRY): removing function bodies from project sources"
 endif
 
 # Link project and proof sources into the proof harness
 $(HARNESS_GOTO)1.goto: $(PROOF_GOTO)1.goto $(PROJECT_GOTO)2.goto
 	$(LITANI) add-job \
-	  --command '$(GOTO_CC) --function $(HARNESS_ENTRY) $^ -o $@' \
+	  --command '$(GOTO_CC) $(CBMC_VERBOSITY) --function $(HARNESS_ENTRY) $^ -o $@' \
 	  --inputs $^ \
-	  --outputs $@ $(call LOG_FROM_ENTRY,$@) \
+	  --outputs $@ \
 	  --pipeline-name $(HARNESS_ENTRY) \
 	  --ci-stage build \
-	  --interleave-stdout-stderr \
-	  --stdout-file $(call LOG_FROM_ENTRY,$@) \
 	  --description "$(HARNESS_ENTRY): linking project to proof"
 
 # Optionally fill static variable with unconstrained values
@@ -340,22 +322,18 @@ ifeq ($(NONDET_STATIC),"")
 	$(LITANI) add-job \
 	  --command 'cp $^ $@' \
 	  --inputs $^ \
-	  --outputs $@ $(call LOG_FROM_ENTRY,$@)\
+	  --outputs $@ \
 	  --pipeline-name $(HARNESS_ENTRY) \
 	  --ci-stage build \
-	  --interleave-stdout-stderr \
-	  --stdout-file $(call LOG_FROM_ENTRY,$@) \
 	  --description "$(HARNESS_ENTRY): not setting static variables to nondet"
 else
 	$(LITANI) add-job \
 	  --command \
 	    '$(GOTO_INSTRUMENT) $(CBMC_VERBOSITY) $(NONDET_STATIC) $^ $@' \
 	  --inputs $^ \
-	  --outputs $@ $(call LOG_FROM_ENTRY,$@) \
+	  --outputs $@ \
 	  --pipeline-name $(HARNESS_ENTRY) \
 	  --ci-stage build \
-	  --interleave-stdout-stderr \
-	  --stdout-file $(call LOG_FROM_ENTRY,$@) \
 	  --description "$(HARNESS_ENTRY): setting static variables to nondet"
 endif
 
@@ -365,11 +343,9 @@ $(HARNESS_GOTO)3.goto: $(HARNESS_GOTO)2.goto
 	  --command \
 	    '$(GOTO_INSTRUMENT) $(CBMC_VERBOSITY) --drop-unused-functions $^ $@' \
 	  --inputs $^ \
-	  --outputs $@ $(call LOG_FROM_ENTRY,$@) \
+	  --outputs $@ \
 	  --pipeline-name $(HARNESS_ENTRY) \
 	  --ci-stage build \
-	  --interleave-stdout-stderr \
-	  --stdout-file $(call LOG_FROM_ENTRY,$@) \
 	  --description "$(HARNESS_ENTRY): dropping unused functions"
 
 # Omit initialization of unused global variables (reduces problem size)
@@ -378,32 +354,20 @@ $(HARNESS_GOTO)4.goto: $(HARNESS_GOTO)3.goto
 	  --command \
 	    '$(GOTO_INSTRUMENT) $(CBMC_VERBOSITY) --slice-global-inits $^ $@' \
 	  --inputs $^ \
-	  --outputs $@ $(call LOG_FROM_ENTRY,$@) \
+	  --outputs $@ \
 	  --pipeline-name $(HARNESS_ENTRY) \
 	  --ci-stage build \
-	  --interleave-stdout-stderr \
-	  --stdout-file $(call LOG_FROM_ENTRY,$@) \
-	  --description "$(HARNESS_ENTRY): omitting unused global initializations"
+	  --description "$(HARNESS_ENTRY): slicing global initializations"
 
 # Final name for proof harness
 $(HARNESS_GOTO).goto: $(HARNESS_GOTO)4.goto
 	$(LITANI) add-job \
 	  --command 'cp $< $@' \
 	  --inputs $^ \
-	  --outputs $@ $(call LOG_FROM_ENTRY,$@)\
+	  --outputs $@ \
 	  --pipeline-name $(HARNESS_ENTRY) \
 	  --ci-stage build \
-	  --interleave-stdout-stderr \
-	  --stdout-file $(call LOG_FROM_ENTRY,$@) \
 	  --description "$(HARNESS_ENTRY): copying final goto-binary"
-
-_goto: $(HARNESS_GOTO).goto
-	echo $(DEPENDENT_GOTOS)
-goto:
-	$(LITANI) init --project $(PROJECT_NAME)
-	$(MAKE) -B _goto
-	$(LITANI) run-build
-
 
 ################################################################
 # Targets to run Arpa
@@ -449,7 +413,7 @@ $(LOGDIR)/result.xml: $(HARNESS_GOTO).goto
 $(LOGDIR)/property.xml: $(HARNESS_GOTO).goto
 	$(LITANI) add-job \
 	  --command \
-	    '$(CBMC) $(CBMC_VERBOSITY) $(CBMCFLAGS) $(CHECKFLAGS) --show-properties --xml-ui $<' \
+	    '$(CBMC) $(CBMC_VERBOSITY) $(CBMCFLAGS) $(CHECKFLAGS) --unwinding-assertions --show-properties --xml-ui $<' \
 	  --inputs $^ \
 	  --outputs $@ \
 	  --pipeline-name $(HARNESS_ENTRY) \
@@ -471,25 +435,6 @@ $(LOGDIR)/coverage.xml: $(HARNESS_GOTO).goto
 	  --tags "stats-group:coverage computation" \
 	  --description "$(HARNESS_ENTRY): calculating coverage"
 
-_result: $(LOGDIR)/result.txt
-result:
-	$(LITANI) init --project $(PROJECT_NAME)
-	$(MAKE) -B _result
-	$(LITANI) run-build
-
-
-_property: $(LOGDIR)/property.xml
-property:
-	$(LITANI) init --project $(PROJECT_NAME)
-	$(MAKE) -B _property
-	$(LITANI) run-build
-
-_coverage: $(LOGDIR)/coverage.xml
-coverage:
-	$(LITANI) init --project $(PROJECT_NAME)
-	$(MAKE) -B _coverage
-	$(LITANI) run-build
-
 define VIEWER_CMD
   $(VIEWER) \
     --result $(LOGDIR)/result.txt \
@@ -501,7 +446,7 @@ define VIEWER_CMD
 endef
 export VIEWER_CMD
 
-_report: $(LOGDIR)/result.txt $(LOGDIR)/property.xml $(LOGDIR)/coverage.xml
+$(PROOFDIR)/html: $(LOGDIR)/result.txt $(LOGDIR)/property.xml $(LOGDIR)/coverage.xml
 	$(LITANI) add-job \
 	  --command "$$VIEWER_CMD" \
 	  --inputs $^ \
@@ -509,17 +454,8 @@ _report: $(LOGDIR)/result.txt $(LOGDIR)/property.xml $(LOGDIR)/coverage.xml
 	  --pipeline-name $(HARNESS_ENTRY) \
 	  --ci-stage report \
 	  --tags "stats-group:report generation" \
-	  --interleave-stdout-stderr \
 	  --description "$(HARNESS_ENTRY): generating report"
-report:
-	$(LITANI) init --project $(PROJECT_NAME)
-	$(MAKE) -B _report
-	$(LITANI) run-build
 
-report:
-	$(LITANI) init --project $(PROJECT_NAME)
-	$(MAKE) -B _report
-	$(LITANI) run-build
 
 # Caution: run make-source before running property and coverage checking
 # The current make-source script removes the goto binary
@@ -543,7 +479,7 @@ export VIEWER2_CMD
 # Omit logs/source.json from report generation until make-sources
 # works correctly with Makefiles that invoke the compiler with
 # mutliple source files at once.
-_report2: $(LOGDIR)/result.xml $(LOGDIR)/property.xml $(LOGDIR)/coverage.xml
+$(PROOFDIR)/report: $(LOGDIR)/result.xml $(LOGDIR)/property.xml $(LOGDIR)/coverage.xml
 	$(LITANI) add-job \
 	  --command "$$VIEWER2_CMD" \
 	  --inputs $^ \
@@ -552,18 +488,55 @@ _report2: $(LOGDIR)/result.xml $(LOGDIR)/property.xml $(LOGDIR)/coverage.xml
 	  --ci-stage report \
 	  --tags "stats-group:report generation" \
 	  --description "$(HARNESS_ENTRY): generating report"
-report2:
-	$(LITANI) init --project $(PROJECT_NAME)
-	$(MAKE) -B _report2
-	$(LITANI) run-build
-
-report2:
-	$(LITANI) init --project $(PROJECT_NAME)
-	$(MAKE) -B _report2
-	$(LITANI) run-build
 
 litani-path:
 	@echo $(LITANI)
+
+# ##############################################################
+# Phony Rules
+#
+#	These rules provide a convenient way to run a single proof up to a
+#	certain stage. Users can browse into a proof directory and run
+#	"make -Bj 3 report" to generate a report for just that proof, or
+#	"make goto" to build the goto binary. Under the hood, this runs litani
+#	for just that proof.
+
+_goto: $(HARNESS_GOTO).goto
+goto:
+	$(LITANI) init --project $(PROJECT_NAME)
+	$(MAKE) -B _goto
+	$(LITANI) run-build
+
+_result: $(LOGDIR)/result.txt
+result:
+	$(LITANI) init --project $(PROJECT_NAME)
+	$(MAKE) -B _result
+	$(LITANI) run-build
+
+_property: $(LOGDIR)/property.xml
+property:
+	$(LITANI) init --project $(PROJECT_NAME)
+	$(MAKE) -B _property
+	$(LITANI) run-build
+
+_coverage: $(LOGDIR)/coverage.xml
+coverage:
+	$(LITANI) init --project $(PROJECT_NAME)
+	$(MAKE) -B _coverage
+	$(LITANI) run-build
+
+_report: $(PROOFDIR)/html
+report:
+	$(LITANI) init --project $(PROJECT_NAME)
+	$(MAKE) -B _report
+	$(LITANI) run-build
+
+_report2: $(PROOFDIR)/report
+report2:
+	$(LITANI) init --project $(PROJECT_NAME)
+	$(MAKE) -B _report2
+	$(LITANI) run-build
+
 
 ################################################################
 # Targets to clean up after ourselves
@@ -579,24 +552,24 @@ veryclean: clean
 	-$(RM) -r $(LOGDIR) $(GOTODIR)
 
 .PHONY: \
+  _coverage \
+  _goto \
+  _property \
+  _report \
+  _report2 \
+  _result \
   arpa \
   clean \
   coverage \
-  _coverage \
   goto \
-  _goto \
   litani-path \
   property \
-  _property \
   report \
-  _report \
   report2 \
-  _report2 \
   result \
-  _result \
+  setup_dependencies \
   testdeps \
   veryclean \
-  setup_dependencies \
   #
 
 ################################################################


### PR DESCRIPTION
This pull request is emphatically *not* against the master branch. It creates a new branch, `litani-mainline`, which will exist in parallel with `master` until all projects are using Litani. The plan is:
* Each project will be updated to use Litani, and their template submodule will point to the `litani-mainline` branch of this repository rather than `master`.
* Projects that haven't been updated to Litani yet will continue to have a submodule pointing to `master`.
* Development on this repository should continue on the `master` branch as usual. I will forward-port all commits from `master` to `litani-mainline` so that Litani-using projects can use them too.
* When all projects are using Litani, we'll merge the `litani-mainline` branch into master. The merge should be trivial since the commits should all be there, just in a different order.

This pull request updates `Makefile.common` to invoke CBMC and related tools through the Litani build accumulator, hosted [here](https://github.com/awslabs/aws-build-accumulator/).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
