### PR TITLE
Update proof README.md and repo .gitignore to include arpa information

### DIFF
--- a/template-for-proof/README.md
+++ b/template-for-proof/README.md
@@ -8,3 +8,14 @@ To run the proof.
   to your path.
 * Run "make".
 * Open html/index.html in a web browser.
+
+Getting started with Makefiles using `arpa`
+-------------
+
+The [`arpa`](https://github.com/awslabs/aws-proof-build-assistant) tool helps you get started with writing proof Makefiles.
+
+To use `arpa`.
+* Run "make arpa" to generate a Makefile.arpa that contains relevant build information for the proof.
+* Use Makefile.arpa as the starting point for your proof Makefile by:
+  1. Modifying Makefile.arpa (if required).
+  2. Including Makefile.arpa into the existing proof Makefile.

--- a/template-for-proof/README.md
+++ b/template-for-proof/README.md
@@ -4,18 +4,17 @@
 This directory contains a memory safety proof for <__FUNCTION_NAME__>.
 
 To run the proof.
+-------------
+
 * Add cbmc, goto-cc, goto-instrument, goto-analyzer, and cbmc-viewer
   to your path.
 * Run "make".
 * Open html/index.html in a web browser.
 
-Getting started with Makefiles using `arpa`
+To use [`arpa`](https://github.com/awslabs/aws-proof-build-assistant) to simplify writing Makefiles.
 -------------
 
-The [`arpa`](https://github.com/awslabs/aws-proof-build-assistant) tool helps you get started with writing proof Makefiles.
-
-To use `arpa`.
 * Run "make arpa" to generate a Makefile.arpa that contains relevant build information for the proof.
 * Use Makefile.arpa as the starting point for your proof Makefile by:
   1. Modifying Makefile.arpa (if required).
-  2. Including Makefile.arpa into the existing proof Makefile.
+  2. Including Makefile.arpa into the existing proof Makefile (add `sinclude Makefile.arpa` at the bottom of the Makefile, right before `include ../Makefile.common`).

--- a/template-for-repository/.gitignore
+++ b/template-for-repository/.gitignore
@@ -9,6 +9,7 @@ TAGS-*
 
 # Emitted by Arpa
 arpa_cmake/
+arpa-validation-logs/
 Makefile.arpa
 
 # These files should be overwritten whenever prepare.py runs


### PR DESCRIPTION
*Description of changes:*
I have added content into the proof _README.md_ that details how to use `arpa` during the proof writing process.
I have also added the `arpa` validation output path to the repository _.gitignore_.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
