### PR TITLE
Force cbmc-batch.yaml to include --unwinding-assertions.

### DIFF
--- a/template-for-repository/proofs/Makefile.common
+++ b/template-for-repository/proofs/Makefile.common
@@ -441,7 +441,7 @@ endef
 cbmc-batch.yaml:
 	@$(RM) $@
 	@echo 'build_memory: $(JOB_MEMORY)' > $@
-	@echo 'cbmcflags: $(strip $(call yaml_encode_options,$(CBMCFLAGS)))' >> $@
+	@echo 'cbmcflags: $(strip $(call yaml_encode_options,$(CBMCFLAGS)));--unwinding-assertions' >> $@
 	@echo 'coverage_memory: $(JOB_MEMORY)' >> $@
 	@echo "expected: SUCCESSFUL" >> $@
 	@echo "goto: $(HARNESS_GOTO).goto" >> $@

--- a/template-for-repository/proofs/Makefile.common
+++ b/template-for-repository/proofs/Makefile.common
@@ -438,10 +438,12 @@ define yaml_encode_options
 	"$(shell echo $(1) | sed 's/ ,/ /g' | sed 's/ /;/g')"
 endef
 
+CBMCFLAGS2 = $(CBMCFLAGS) --unwinding-assertions
+
 cbmc-batch.yaml:
 	@$(RM) $@
 	@echo 'build_memory: $(JOB_MEMORY)' > $@
-	@echo 'cbmcflags: $(strip $(call yaml_encode_options,$(CBMCFLAGS)));--unwinding-assertions' >> $@
+	@echo 'cbmcflags: $(strip $(call yaml_encode_options,$(CBMCFLAGS2)))' >> $@
 	@echo 'coverage_memory: $(JOB_MEMORY)' >> $@
 	@echo "expected: SUCCESSFUL" >> $@
 	@echo "goto: $(HARNESS_GOTO).goto" >> $@


### PR DESCRIPTION
This pull request modifies the cbmc-batch.yaml target of Makefile.common to force the inclusion of --unwinding-assertions.

The new starter kit template assumes CFLAGS does not contain --unwinding-assertions and explicitly adds it when doing property checking.  The continuous integration assumes CFLAGS does contain --unwinding-assertions and explicitly filters it out when doing coverage checking.

Before this change, cbmc-batch.yaml included
```
cbmcflags: "--unwind;1;--unwindset;__CPROVER_file_local_mqtt_c_sendPacket.0:3;--object-bits;8"
```
After this change, cbmc-batch.yaml includes
```
cbmcflags: "--unwind;1;--unwindset;__CPROVER_file_local_mqtt_c_sendPacket.0:3;--object-bits;8;--unwinding-assertions"
```