### PR TITLE
Add a validation script for Arpa

### DIFF
--- a/template-for-repository/.gitignore
+++ b/template-for-repository/.gitignore
@@ -7,9 +7,11 @@ proofs/**/html
 # Emitted by CBMC Viewer
 TAGS-*
 
-# Emitted by Arpa
+# Emitted by Arpa and its validator
 arpa_cmake/
 Makefile.arpa
+arpa-test-results.log
+arpa-test-logs
 
 # These files should be overwritten whenever prepare.py runs
 cbmc-batch.yaml

--- a/template-for-repository/.gitignore
+++ b/template-for-repository/.gitignore
@@ -7,7 +7,7 @@ proofs/**/html
 # Emitted by CBMC Viewer
 TAGS-*
 
-# Emitted by Arpa and its validator
+# Emitted by Arpa and its validation script
 arpa_cmake/
 Makefile.arpa
 arpa-test-results.log

--- a/template-for-repository/proofs/arpa-test.sh
+++ b/template-for-repository/proofs/arpa-test.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# This script performs validation for arpa
+
+makefile=Makefile
+results=arpa-test-results.log
+
+arpa_log=arpa-test-logs
+goto_functions_std=$arpa_log/goto-functions-std
+goto_functions_arpa=$arpa_log/goto-functions-arpa
+
+
+function initialize {
+        rm -f $results
+}
+
+
+function look_for {
+    if [ ! -f $1 ]; then
+        echo "-- $1 does not exist in ($dir)." 1>&2
+        echo "<SKIPPING>" 1>&2
+        cd ..
+        echo "ERROR  -  $dir" >> $results
+        continue
+    fi
+}
+
+
+function get_functions {
+        cbmc --show-goto-functions gotos/$harness.goto
+}
+
+
+function make_std {
+    make veryclean
+    make goto
+    fcts_std=$(get_functions)
+    fcts_std_clean=$(grep -v " *//.*" <<< "$fcts_std")
+}
+
+
+function make_arpa {
+    make veryclean
+    make arpa
+
+    makefile_temp=$(sed -e 's-PROOF_SOURCES += \$(PROOF_SOURCE).*--g' \
+        -e 's-PROJECT_SOURCES += .*--g' \
+        -e 's-include ../Makefile.common-include Makefile.arpa\'$'\ninclude ../Makefile.common-g'\
+        $makefile)
+
+    make goto -f <(echo "$makefile_temp")
+    fcts_arpa=$(get_functions)
+    fcts_arpa_clean=$(grep -v " *//.*" <<< "$fcts_arpa")
+}
+
+
+function write_failure_log {
+    mkdir -p $arpa_log
+    cp Makefile.arpa $arpa_log
+    cp arpa_cmake/compile_commands.json $arpa_log
+    echo "$fcts_std_clean" > $goto_functions_std
+    echo "$fcts_arpa_clean" > $goto_functions_arpa
+}
+
+
+function compare_and_report {
+    # compare functions list
+    is_dif=$(diff -q <(echo "$fcts_std_clean") \
+        <(echo "$fcts_arpa_clean"))
+
+    # report
+    echo -n "<END - "
+    if [ "$is_dif" ]; then
+        # goto functions are different
+        echo -n "(DIFFERENT)"
+        echo "FAILURE  -  $dir" >> ../$results
+
+        #write files to arpa_log
+        write_failure_log
+    else
+        # goto functions are identical
+        echo -n "(IDENTICAL)"
+        echo "SUCCESS  -  $dir" >> ../$results
+    fi
+    echo " >"
+}
+
+
+# MAIN
+initialize
+for dir in *; do
+    if [ ! -d $dir ]; then
+        continue
+    fi
+
+    cd $dir
+    harness="$dir"_harness.c
+    echo -e "\n<BEGIN - ($dir) >"
+
+    # check files
+    look_for $makefile
+    look_for $harness
+
+    # define fcts_std_clean
+    echo "-- Listing goto functions for STANDARD approach"
+    make_std > /dev/null
+
+    # define fcts_arpa_clean
+    echo "-- Listing goto functions for ARPA approach"
+    make_arpa > /dev/null
+
+    # compare goto functions
+    compare_and_report
+
+    # clean up
+    make veryclean > /dev/null
+    cd ..
+done

--- a/template-for-repository/proofs/arpa-test.sh
+++ b/template-for-repository/proofs/arpa-test.sh
@@ -7,6 +7,7 @@
 # Furthermore, it serves as a validation framework for existing CBMC proofs.
 
 # TODO add project-specific list of proofs that fail, but should be overriden due to limitations of the validation approach
+# The list below must be seperated by spaces
 manual_proof_override=""
 
 
@@ -157,7 +158,7 @@ function write_proof_stats {
         deps_not_found=$(comm -13 <(echo "$sorted_no_stubs_arpa") <(echo "$sorted_no_stubs_std"))
         while read -r l; do
             to_add="$(sed -e 's-.* += --g' <<< "$l" )"
-            if [[ ! "$list_deps_arpa_cannot_find" == *"$to_add"* ]]; then
+            if [[ ! "$list_deps_arpa_cannot_find" == *"    $to_add\n"* ]]; then
                 list_deps_arpa_cannot_find+="    $to_add\n"
             fi
         done <<< "$deps_not_found"
@@ -269,7 +270,7 @@ function ask_override {
     fi
 
     # ... or automatically.
-    if [[ "$manual_proof_override" == *"$dir"* ]]; then
+    if [[ "$manual_proof_override" =~ (^| )"$dir"($| ) ]]; then
         override="y"
         return
     else

--- a/template-for-repository/proofs/arpa-test.sh
+++ b/template-for-repository/proofs/arpa-test.sh
@@ -6,7 +6,7 @@
 # This script performs  data collection for Arpa.
 # Furthermore, it serves as a validation framework for existing CBMC proofs.
 
-# TODO project-specific list of proofs that fail, but where results should be overriden due to limitations of the validation approach
+# TODO add project-specific list of proofs that fail, but should be overriden due to limitations of the validation approach
 # TODO _ remove for s2n
 manual_proof_override="s2n_blob_zeroize_free  s2n_free  s2n_free_object  s2n_pkcs3_to_dh_params  s2n_stuffer_peek_check_for_str  s2n_stuffer_read_expected_str  s2n_stuffer_write_vector_size"
 
@@ -185,7 +185,7 @@ function write_proof_stats {
     r_deps_found=$((n_deps_com * 100 / n_deps_nesc))
 
     echo "  2.-PROOF STATS : #deps-in-std=$n_deps_std ($n_stubs_std stubs, $n_deps_unnesc unnesc), #deps-in-arpa=$n_deps_arpa ($n_stubs_arpa stubs), #non-stub-deps-in-common=$n_deps_com"
-    echo "     \-ARPA FINDS: %of-nesc-non-stub-deps=$r_deps_found% ($n_deps_com/$n_deps_nesc), #additional-deps=$n_add_deps ($n_stubs_arpa stubs)"
+    echo "    \-ARPA FINDS: %of-nesc-non-stub-deps=$r_deps_found% ($n_deps_com/$n_deps_nesc), #additional-deps=$n_add_deps ($n_stubs_arpa stubs)"
 }
 
 
@@ -214,11 +214,11 @@ function write_total_stats {
     # total percentage of non-stub necessary dependencies found by arpa
     r_t_deps_found=$((t_deps_com * 100 / t_deps_nesc))
     echo "  4.-TOTAL STATS : #deps-in-std=$t_deps_std ($t_stubs_std stubs, $t_deps_unnesc unnesc in $t_pfs_w_unnesc proofs), #deps-in-arpa=$t_deps_arpa, #non-stub-deps-in-common=$t_deps_com"
-    echo "     \-ARPA FINDS: %of-nesc-non-stub-deps=$r_t_deps_found% ($t_deps_com/$t_deps_nesc), #additional-deps=$t_add_deps ($t_stubs_arpa stubs)"
+    echo "    \-ARPA FINDS: %of-nesc-non-stub-deps=$r_t_deps_found% ($t_deps_com/$t_deps_nesc), #additional-deps=$t_add_deps ($t_stubs_arpa stubs)"
     
     # average percentage of non-stub dependencies found by arpa per proof
     avg_r_deps_found=$(((avg_r_deps_found * (n_prfs -1) + r_deps_found) / n_prfs))
-    echo "     \-AVERAGE   : avg%deps_found_per_proof=$avg_r_deps_found%"
+    echo "    \-AVERAGE   : avg%deps_found_per_proof=$avg_r_deps_found%"
 }
 
 

--- a/template-for-repository/proofs/arpa-test.sh
+++ b/template-for-repository/proofs/arpa-test.sh
@@ -7,10 +7,24 @@
 
 makefile=Makefile
 results=arpa-test-results.log
+csv=arpa-test-results.csv
 
 arpa_log=arpa-test-logs
 goto_functions_std=$arpa_log/goto-functions-std
 goto_functions_arpa=$arpa_log/goto-functions-arpa
+
+#data collection
+n_prfs=0
+n_succ=0
+
+t_deps_std=0 # sum of all n_deps_std
+t_deps_arpa=0 # sum of all n_deps_arpa
+
+avg_r_deps_proof=0
+
+list_deps_arpa_cannot_find+="" 
+list_deps_arpa_has_found_at_least_once+=""
+list_deps_that_currently_exist_but_are_irrelevant+="" # case where arpa finds less deps but diff of show_goto_functions is the same
 
 
 function initialize {
@@ -29,35 +43,52 @@ function look_for {
 }
 
 
-function get_functions {
-        cbmc --show-goto-functions gotos/$harness.goto
+function get_fcts {
+    goto_fcts=$(cbmc --show-goto-functions gotos/$harness.goto)
+    # eval fcts_$1="\$goto_fcts"
+    clean_goto_fcts=$(grep -v " *//.*" <<< "$goto_fcts")
+    eval fcts_$1_clean="\$clean_goto_fcts"
+}
+
+
+function get_deps {
+    grep_out=$(grep 'PROOF_SOURCES += \$(PROOF_SOURCE).*\|PROJECT_SOURCES += .*' $2)
+    eval deps_$1="\$grep_out"
+    eval n_deps_$1=$(wc -l <<< "$grep_out" | tr -d " ")
 }
 
 
 function make_std {
     make veryclean
     make goto
-    fcts_std=$(get_functions)
-    fcts_std_clean=$(grep -v " *//.*" <<< "$fcts_std")
+
+    get_fcts std
+    get_deps std Makefile
 }
 
 
 function make_arpa {
     make veryclean
     make arpa
+    # remove includes and defines from Makefile.arpa
+    sed -i '' -e 's-DEFINES += .*--g' \
+        -e 's-INCLUDES += .*--g' \
+        Makefile.arpa
 
     makefile_temp=$(sed -e 's-PROOF_SOURCES += \$(PROOF_SOURCE).*--g' \
         -e 's-PROJECT_SOURCES += .*--g' \
         -e 's-include ../Makefile.common-include Makefile.arpa\'$'\ninclude ../Makefile.common-g'\
         $makefile)
+    # TODO put iclude arpa after PROOF_SOURCES += $(HARENSS_FILE)
 
     make goto -f <(echo "$makefile_temp")
-    fcts_arpa=$(get_functions)
-    fcts_arpa_clean=$(grep -v " *//.*" <<< "$fcts_arpa")
+
+    get_fcts arpa
+    get_deps arpa Makefile.arpa
 }
 
 
-function write_failure_log {
+function write_failure_docs {
     mkdir -p $arpa_log
     cp Makefile.arpa $arpa_log
     cp arpa_cmake/compile_commands.json $arpa_log
@@ -66,32 +97,115 @@ function write_failure_log {
 }
 
 
+function write_to_log {
+    # WRITE RESULT
+    echo "$1  -  $dir" >> ../$results
+
+
+    r_succ=$((n_succ * 100 / n_prfs))
+    echo "    \-SUCC RATE:#proofs=$n_prfs, #succ=$n_succ, %succ=$r_succ%" >> ../$results
+
+    ##############################
+    ### PER PROOF MEASUREMENTS
+    ##############################
+    if [ "$is_dif" ]; then
+        # we assume that all included dependencies are required
+        # we assume that arpa does not find any irrelevant dependencies
+        n_deps_irrelevant=0
+        n_deps_missing=$((n_deps_std-n_deps_arpa))
+
+        not_found="$(comm -13 <(sort <<< "$deps_arpa") <(sort <<< "$deps_std"))"
+        while read -r l; do
+            to_add="$(sed -e 's-PROJECT_SOURCES += --g' <<< "$l" )"
+            if [[ ! "$list_deps_arpa_cannot_find" == *"$to_add"* ]]; then
+                list_deps_arpa_cannot_find+="$to_add"
+                list_deps_arpa_cannot_find+=", "
+            fi
+        done <<< "$not_found"
+    else
+        n_deps_irrelevant=$((n_deps_std-n_deps_arpa))
+        n_deps_missing=0
+    fi
+
+    if [ $n_deps_irrelevant -lt 0 ]; then
+        #found a stub!!!
+        n_stubs=$((0 - n_deps_irrelevant))
+
+        #### ASSUMPTION: the STUBS directory is a recursive subdirectory of the PROOF_SOURCE directory
+        echo "     -(ARPA has found ($n_stubs) STUBS!)" >> ../$results
+        n_deps_arpa=$((n_deps_std))
+        n_deps_irrelevant=0
+    fi
+    n_deps_relevant=$((n_deps_std-n_deps_irrelevant))
+    # r_deps_proof=$((n_deps_arpa * 100 / n_deps_relevant))
+
+
+    echo "    \-PROOF -STD : #deps_incl=$n_deps_std, #deps_irrelevant=$n_deps_irrelevant, #deps_relevant=$n_deps_relevant" >> ../$results
+    echo "            -ARPA: #deps_found=$n_deps_arpa, #missing_deps=$n_deps_missing, %relevant_deps_found=$r_deps_proof%" >> ../$results
+
+    ##############################
+    ### TOTAL MEASUREMENTS
+    ##############################
+    # assuming Arpa does ot find irrelevant deps
+    ((t_deps_std=t_deps_std+n_deps_std))
+    ((t_deps_arpa=t_deps_arpa+n_deps_arpa))
+
+    t_deps_irrelevant=$((t_deps_irrelevant+n_deps_irrelevant))
+    t_deps_relevant=$((t_deps_std-t_deps_irrelevant))
+    t_deps_missing=$((t_deps_missing+n_deps_missing))
+
+    r_deps_total=$((t_deps_arpa * 100 / t_deps_relevant))
+    echo "    \-TOTAL -STD : #deps_incl=$t_deps_std, #deps_irrelevant=$t_deps_irrelevant, #deps_relevant=$t_deps_relevant" >> ../$results
+    echo "            -ARPA: #deps_found=$t_deps_arpa, #missing_deps=$t_deps_missing, %relevant_deps_found=$r_deps_total%" >> ../$results
+
+    ##############################
+    ### AVERAGE RATIO MEASUREMENTS
+    ##############################
+    avg_r_deps_proof=$(((avg_r_deps_proof * (n_prfs -1) + r_deps_proof) / n_prfs))
+    echo "    \-AVERAGE    : avg%deps_found_per_proof=$avg_r_deps_proof%" >> ../$results
+
+    ##############################
+    ### RELEVANT LISTS
+    ##############################
+
+    echo "    \-LISTS -DEPS_MISSED_AT_LEAST_ONCE: $list_deps_arpa_cannot_find" >> ../$results
+    # echo "            -DEPS_FOUND_AT_LEAST_ONCE : " >> ../$results
+    # echo "            -DEPS_IRREL_AT_LEAST_ONCE : " >> ../$results
+
+    echo "" >> ../$results
+}
+
+
 function compare_and_report {
+    # write csv header
+    echo "Proof,Success?,#deps-std,#deps-arpa,#deps-common" > ../$csv
+
     # compare functions list
     is_dif=$(diff -q <(echo "$fcts_std_clean") \
         <(echo "$fcts_arpa_clean"))
 
     # report
+    ((n_prfs=n_prfs+1))
     echo -n "<END - "
     if [ "$is_dif" ]; then
         # goto functions are different
         echo -n "(DIFFERENT)"
-        echo "FAILURE  -  $dir" >> ../$results
-
-        #write files to arpa_log
-        write_failure_log
+        write_to_log FAILURE
+        write_failure_docs
     else
         # goto functions are identical
+        ((n_succ=n_succ+1))
         echo -n "(IDENTICAL)"
-        echo "SUCCESS  -  $dir" >> ../$results
+        write_to_log SUCCESS
     fi
     echo " >"
+    # echo "$deps_arpa"
 }
 
 
 # MAIN
 initialize
-for dir in *; do
+for dir in s2n_stuffer_write_uint32; do
     if [ ! -d $dir ]; then
         continue
     fi
@@ -113,6 +227,7 @@ for dir in *; do
     make_arpa > /dev/null
 
     # compare goto functions
+    echo "-- Comparing results and writing report"
     compare_and_report
 
     # clean up

--- a/template-for-repository/proofs/arpa-test.sh
+++ b/template-for-repository/proofs/arpa-test.sh
@@ -7,8 +7,7 @@
 # Furthermore, it serves as a validation framework for existing CBMC proofs.
 
 # TODO add project-specific list of proofs that fail, but should be overriden due to limitations of the validation approach
-# TODO _ remove for s2n
-manual_proof_override="s2n_blob_zeroize_free  s2n_free  s2n_free_object  s2n_pkcs3_to_dh_params  s2n_stuffer_peek_check_for_str  s2n_stuffer_read_expected_str  s2n_stuffer_write_vector_size"
+manual_proof_override=""
 
 
 function initialize {
@@ -107,12 +106,6 @@ function make_arpa {
     make veryclean
     make arpa
     get_deps arpa Makefile.arpa
-
-    # Remove defines and includes from the generated Makefile.arpa, for consistency
-    # TODO _ remove for s2n
-    sed -i '' -e 's-DEFINES += .*--g' \
-        -e 's-INCLUDES += .*--g' \
-        Makefile.arpa
 
     # remove all dependencies (except stubs) from the current makefile
     # and add the "include Makefile.arpa" line


### PR DESCRIPTION
*Description of changes:*
I have added a script that allows to evaluate and validate the effectiveness of `arpa` if it is being used as the sole source of dependencies for a given proof.

The [proposed validation script](https://github.com/ArenBabikian/aws-templates-for-cbmc-proofs/blob/master/template-for-repository/proofs/arpa-test.sh) compares the goto functions incorporated during proof runs with and without the use of `arpa`. After running each approach, I run the `cbmc --show-goto-functions gotos/harness_file_name.goto` command and compare the outputs (after post-processing). If the post-processed outputs are identical, then the script concludes that `arpa` was able to find all dependencies.

Currently, this validation script has been tested successfully on [S2N](https://github.com/awslabs/s2n).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
