### PR TITLE
Ensure CI uses CHECKFLAGS

### DIFF
--- a/template-for-repository/proofs/Makefile.common
+++ b/template-for-repository/proofs/Makefile.common
@@ -438,12 +438,12 @@ define yaml_encode_options
 	"$(shell echo $(1) | sed 's/ ,/ /g' | sed 's/ /;/g')"
 endef
 
-CBMCFLAGS2 = $(CBMCFLAGS) --unwinding-assertions
+CI_FLAGS = $(CBMCFLAGS) $(CHECKFLAGS) $(COVERFLAGS) --unwinding-assertions
 
 cbmc-batch.yaml:
 	@$(RM) $@
 	@echo 'build_memory: $(JOB_MEMORY)' > $@
-	@echo 'cbmcflags: $(strip $(call yaml_encode_options,$(CBMCFLAGS2)))' >> $@
+	@echo 'cbmcflags: $(strip $(call yaml_encode_options,$(CI_FLAGS)))' >> $@
 	@echo 'coverage_memory: $(JOB_MEMORY)' >> $@
 	@echo "expected: SUCCESSFUL" >> $@
 	@echo "goto: $(HARNESS_GOTO).goto" >> $@


### PR DESCRIPTION
This PR makes the cbmc-batch.yaml rule emit the CHECKFLAGS variable
to the YAML file as well as the CBMCFLAGS. This fixes a bug where CI was
not checking any of the properties because the property checks are all
part of the CHECKFLAGS variable.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
