### PR TITLE
Allow overriding expected CBMC result

### DIFF
--- a/template-for-repository/proofs/Makefile.common
+++ b/template-for-repository/proofs/Makefile.common
@@ -446,9 +446,9 @@ cbmc-batch.yaml:
 	@echo 'build_memory: $(JOB_MEMORY)' > $@
 	@echo 'cbmcflags: $(strip $(call yaml_encode_options,$(CI_FLAGS)))' >> $@
 	@echo 'coverage_memory: $(JOB_MEMORY)' >> $@
-	@echo "expected: $(EXPECTED)" >> $@
-	@echo "goto: $(HARNESS_GOTO).goto" >> $@
-	@echo "jobos: $(JOB_OS)" >> $@
+	@echo 'expected: $(EXPECTED)' >> $@
+	@echo 'goto: $(HARNESS_GOTO).goto' >> $@
+	@echo 'jobos: $(JOB_OS)' >> $@
 	@echo 'property_memory: $(JOB_MEMORY)' >> $@
 	@echo 'report_memory: $(JOB_MEMORY)' >> $@
 

--- a/template-for-repository/proofs/Makefile.common
+++ b/template-for-repository/proofs/Makefile.common
@@ -433,6 +433,10 @@ veryclean: clean
 
 JOB_OS ?= ubuntu16
 JOB_MEMORY ?= 32000
+
+# Proofs that are expected to fail should set EXPECTED to
+# "FAILED" in their Makefile. Values other than SUCCESSFUL
+# or FAILED will cause a CI error.
 EXPECTED ?= SUCCESSFUL
 
 define yaml_encode_options

--- a/template-for-repository/proofs/Makefile.common
+++ b/template-for-repository/proofs/Makefile.common
@@ -433,6 +433,7 @@ veryclean: clean
 
 JOB_OS ?= ubuntu16
 JOB_MEMORY ?= 32000
+EXPECTED ?= SUCCESSFUL
 
 define yaml_encode_options
 	"$(shell echo $(1) | sed 's/ ,/ /g' | sed 's/ /;/g')"
@@ -445,7 +446,7 @@ cbmc-batch.yaml:
 	@echo 'build_memory: $(JOB_MEMORY)' > $@
 	@echo 'cbmcflags: $(strip $(call yaml_encode_options,$(CI_FLAGS)))' >> $@
 	@echo 'coverage_memory: $(JOB_MEMORY)' >> $@
-	@echo "expected: SUCCESSFUL" >> $@
+	@echo "expected: $(EXPECTED)" >> $@
 	@echo "goto: $(HARNESS_GOTO).goto" >> $@
 	@echo "jobos: $(JOB_OS)" >> $@
 	@echo 'property_memory: $(JOB_MEMORY)' >> $@


### PR DESCRIPTION
This PR adds a new parameter in the Makefile that allows overriding `expected` (the expected result from CBMC) in the auto-generated `cbmc-batch.yaml` files.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
