### PR TITLE
Add CBMC CHECKFLAGS for external SAT solver using ENVVAR

### DIFF
--- a/template-for-repository/proofs/Makefile.common
+++ b/template-for-repository/proofs/Makefile.common
@@ -112,6 +112,9 @@ CBMCDIR ?= $(PROOF_ROOT)/cbmc
 CBMCFLAGS += --unwind 1 $(CBMC_UNWINDSET)
 
 # Additional CBMC flags used for property checking
+ifneq ($(EXTERNAL_SAT_SOLVER),)
+   CHECKFLAGS += --external-sat-solver $(EXTERNAL_SAT_SOLVER)
+endif
 CHECKFLAGS += --bounds-check
 CHECKFLAGS += --conversion-check
 CHECKFLAGS += --div-by-zero-check

--- a/template-for-repository/proofs/Makefile.common
+++ b/template-for-repository/proofs/Makefile.common
@@ -112,7 +112,7 @@ CBMCDIR ?= $(PROOF_ROOT)/cbmc
 CBMCFLAGS += --unwind 1 $(CBMC_UNWINDSET)
 
 # Additional CBMC flags used for property checking
-ifneq ($(EXTERNAL_SAT_SOLVER),)
+ifneq ($(strip $(EXTERNAL_SAT_SOLVER)),)
    CHECKFLAGS += --external-sat-solver $(EXTERNAL_SAT_SOLVER)
 endif
 CHECKFLAGS += --bounds-check


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add --external_sat_solver to CBMC CHECKFLAGS if the environment variable EXTERNAL_SAT_SOLVER is set. This will allow CI to use Kissat as a SAT solver in CBMC. This should speed up proofs that generate hard problems for MiniSAT.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
