### PR TITLE
Added new CBMC flags and support for disabling flags

### DIFF
--- a/template-for-proof/Makefile
+++ b/template-for-proof/Makefile
@@ -1,13 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Additional flags for CBMC
-CBMCFLAGS +=
-CHECKFLAGS +=
-
-# Disabled CBMC flags
-DISABLED_FLAGS =
-
 HARNESS_ENTRY = harness
 HARNESS_FILE = <__FUNCTION_NAME__>_harness
 

--- a/template-for-proof/Makefile
+++ b/template-for-proof/Makefile
@@ -1,8 +1,15 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-HARNESS_ENTRY=harness
-HARNESS_FILE=<__FUNCTION_NAME__>_harness
+# Additional flags for CBMC
+CBMCFLAGS +=
+CHECKFLAGS +=
+
+# Disabled CBMC flags
+DISABLED_FLAGS =
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = <__FUNCTION_NAME__>_harness
 
 DEFINES +=
 INCLUDES +=

--- a/template-for-proof/README.md
+++ b/template-for-proof/README.md
@@ -6,15 +6,15 @@ This directory contains a memory safety proof for <__FUNCTION_NAME__>.
 To run the proof.
 -------------
 
-* Add cbmc, goto-cc, goto-instrument, goto-analyzer, and cbmc-viewer
+* Add `cbmc`, `goto-cc`, `goto-instrument`, `goto-analyzer`, and `cbmc-viewer`
   to your path.
-* Run "make".
+* Run `make`.
 * Open html/index.html in a web browser.
 
 To use [`arpa`](https://github.com/awslabs/aws-proof-build-assistant) to simplify writing Makefiles.
 -------------
 
-* Run "make arpa" to generate a Makefile.arpa that contains relevant build information for the proof.
+* Run `make arpa` to generate a Makefile.arpa that contains relevant build information for the proof.
 * Use Makefile.arpa as the starting point for your proof Makefile by:
   1. Modifying Makefile.arpa (if required).
   2. Including Makefile.arpa into the existing proof Makefile (add `sinclude Makefile.arpa` at the bottom of the Makefile, right before `include ../Makefile.common`).

--- a/template-for-repository/proofs/Makefile.common
+++ b/template-for-repository/proofs/Makefile.common
@@ -95,7 +95,7 @@ sinclude $(PROOF_ROOT)/Makefile-project-defines
 sinclude $(PROOF_ROOT)/Makefile-template-defines
 
 # SRCDIR is the path to the root of the source tree
-SRCDIR ?= $(abspath $(../..)
+SRCDIR ?= $(abspath ../..)
 
 # PROOFDIR is the path to the directory containing the proof harness
 PROOFDIR ?= $(abspath .)
@@ -110,6 +110,11 @@ CBMCDIR ?= $(PROOF_ROOT)/cbmc
 
 # Default CBMC flags used for property checking and coverage checking
 CBMCFLAGS += --unwind 1 $(CBMC_UNWINDSET)
+CBMCFLAGS += --malloc-may-fail
+CBMCFLAGS += --malloc-fail-null
+
+# Removed DISABLED_FLAGS from CBMCFLAGS
+CBMCFLAGS := $(filter-out $(DISABLED_FLAGS),$(CBMCFLAGS))
 
 # Additional CBMC flags used for property checking
 ifneq ($(strip $(EXTERNAL_SAT_SOLVER)),)
@@ -122,9 +127,13 @@ CHECKFLAGS += --float-overflow-check
 CHECKFLAGS += --nan-check
 CHECKFLAGS += --pointer-check
 CHECKFLAGS += --pointer-overflow-check
+CHECKFLAGS += --pointer-primitive-check
 CHECKFLAGS += --signed-overflow-check
 CHECKFLAGS += --undefined-shift-check
 CHECKFLAGS += --unsigned-overflow-check
+
+# Removed DISABLED_FLAGS from CHECKFLAGS
+CHECKFLAGS := $(filter-out $(DISABLED_FLAGS),$(CHECKFLAGS))
 
 # Additional CBMC flags used for coverage checking
 COVERFLAGS +=

--- a/template-for-repository/proofs/Makefile.common
+++ b/template-for-repository/proofs/Makefile.common
@@ -113,7 +113,7 @@ CBMCFLAGS += --malloc-fail-null
 CBMCFLAGS += --malloc-may-fail
 CBMCFLAGS += --unwind 1 $(CBMC_UNWINDSET)
 
-# Removed DISABLED_FLAGS from CBMCFLAGS
+# Remove DISABLED_FLAGS from CBMCFLAGS
 CBMCFLAGS := $(filter-out $(DISABLED_FLAGS),$(CBMCFLAGS))
 
 # Additional CBMC flags used for property checking
@@ -132,7 +132,7 @@ CHECKFLAGS += --signed-overflow-check
 CHECKFLAGS += --undefined-shift-check
 CHECKFLAGS += --unsigned-overflow-check
 
-# Removed DISABLED_FLAGS from CHECKFLAGS
+# Remove DISABLED_FLAGS from CHECKFLAGS
 CHECKFLAGS := $(filter-out $(DISABLED_FLAGS),$(CHECKFLAGS))
 
 # Additional CBMC flags used for coverage checking

--- a/template-for-repository/proofs/Makefile.common
+++ b/template-for-repository/proofs/Makefile.common
@@ -109,9 +109,9 @@ PROOFDIR ?= $(abspath .)
 CBMCDIR ?= $(PROOF_ROOT)/cbmc
 
 # Default CBMC flags used for property checking and coverage checking
-CBMCFLAGS += --unwind 1 $(CBMC_UNWINDSET)
-CBMCFLAGS += --malloc-may-fail
 CBMCFLAGS += --malloc-fail-null
+CBMCFLAGS += --malloc-may-fail
+CBMCFLAGS += --unwind 1 $(CBMC_UNWINDSET)
 
 # Removed DISABLED_FLAGS from CBMCFLAGS
 CBMCFLAGS := $(filter-out $(DISABLED_FLAGS),$(CBMCFLAGS))

--- a/template-for-repository/proofs/Makefile.common
+++ b/template-for-repository/proofs/Makefile.common
@@ -111,24 +111,36 @@ CBMCDIR ?= $(PROOF_ROOT)/cbmc
 # Default CBMC flags used for property checking and coverage checking
 CBMCFLAGS += --unwind 1 $(CBMC_UNWINDSET)
 
-# Additional CBMC flags used for property checking
 ifneq ($(strip $(EXTERNAL_SAT_SOLVER)),)
    CHECKFLAGS += --external-sat-solver $(EXTERNAL_SAT_SOLVER)
 endif
 
+# Additional CBMC flags used for property checking
+#
+# Each variable below controls a specific property checking flag
+# within CBMC. If desired, a property flag can be disabled within
+# a particular proof by nulling the corresponding variable. For
+# instance, the following line:
+#
+#     CHECK_FLAG_POINTER_CHECK =
+#
+# would disable the --pointer-check CBMC flag within:
+#
+# a. an entire project when added to Makefile-project-defines
+# b. a specific proof when added to the harness Makefile
 CBMC_FLAG_MALLOC_MAY_FAIL ?= --malloc-may-fail
 CBMC_FLAG_MALLOC_FAIL_NULL ?= --malloc-fail-null
 CBMC_FLAG_BOUNDS_CHECK ?= --bounds-check
-CHECK_FLAG_CONVERSION_CHECK ?= --conversion-check
-CHECK_FLAG_DIV_BY_ZERO_CHECK ?= --div-by-zero-check
-CHECK_FLAG_FLOAT_OVERFLOW_CHECK ?= --float-overflow-check
-CHECK_FLAG_NAN_CHECK ?= --nan-check
-CHECK_FLAG_POINTER_CHECK ?= --pointer-check
-CHECK_FLAG_POINTER_OVERFLOW_CHECK ?= --pointer-overflow-check
-CHECK_FLAG_POINTER_PRIMITIVE_CHECK ?= --pointer-primitive-check
-CHECK_FLAG_SIGNED_OVERFLOW_CHECK ?= --signed-overflow-check
-CHECK_FLAG_UNDEFINED_SHIFT_CHECK ?= --undefined-shift-check
-CHECK_FLAG_UNSIGNED_OVERFLOW_CHECK ?= --unsigned-overflow-check
+CBMC_FLAG_CONVERSION_CHECK ?= --conversion-check
+CBMC_FLAG_DIV_BY_ZERO_CHECK ?= --div-by-zero-check
+CBMC_FLAG_FLOAT_OVERFLOW_CHECK ?= --float-overflow-check
+CBMC_FLAG_NAN_CHECK ?= --nan-check
+CBMC_FLAG_POINTER_CHECK ?= --pointer-check
+CBMC_FLAG_POINTER_OVERFLOW_CHECK ?= --pointer-overflow-check
+CBMC_FLAG_POINTER_PRIMITIVE_CHECK ?= --pointer-primitive-check
+CBMC_FLAG_SIGNED_OVERFLOW_CHECK ?= --signed-overflow-check
+CBMC_FLAG_UNDEFINED_SHIFT_CHECK ?= --undefined-shift-check
+CBMC_FLAG_UNSIGNED_OVERFLOW_CHECK ?= --unsigned-overflow-check
 
 CHECKFLAGS += $(CBMC_FLAG_MALLOC_MAY_FAIL)
 CHECKFLAGS += $(CBMC_FLAG_MALLOC_FAIL_NULL)

--- a/template-for-repository/proofs/Makefile.common
+++ b/template-for-repository/proofs/Makefile.common
@@ -109,31 +109,40 @@ PROOFDIR ?= $(abspath .)
 CBMCDIR ?= $(PROOF_ROOT)/cbmc
 
 # Default CBMC flags used for property checking and coverage checking
-CBMCFLAGS += --malloc-fail-null
-CBMCFLAGS += --malloc-may-fail
 CBMCFLAGS += --unwind 1 $(CBMC_UNWINDSET)
-
-# Remove DISABLED_FLAGS from CBMCFLAGS
-CBMCFLAGS := $(filter-out $(DISABLED_FLAGS),$(CBMCFLAGS))
 
 # Additional CBMC flags used for property checking
 ifneq ($(strip $(EXTERNAL_SAT_SOLVER)),)
    CHECKFLAGS += --external-sat-solver $(EXTERNAL_SAT_SOLVER)
 endif
-CHECKFLAGS += --bounds-check
-CHECKFLAGS += --conversion-check
-CHECKFLAGS += --div-by-zero-check
-CHECKFLAGS += --float-overflow-check
-CHECKFLAGS += --nan-check
-CHECKFLAGS += --pointer-check
-CHECKFLAGS += --pointer-overflow-check
-CHECKFLAGS += --pointer-primitive-check
-CHECKFLAGS += --signed-overflow-check
-CHECKFLAGS += --undefined-shift-check
-CHECKFLAGS += --unsigned-overflow-check
 
-# Remove DISABLED_FLAGS from CHECKFLAGS
-CHECKFLAGS := $(filter-out $(DISABLED_FLAGS),$(CHECKFLAGS))
+CBMC_FLAG_MALLOC_MAY_FAIL ?= --malloc-may-fail
+CBMC_FLAG_MALLOC_FAIL_NULL ?= --malloc-fail-null
+CBMC_FLAG_BOUNDS_CHECK ?= --bounds-check
+CHECK_FLAG_CONVERSION_CHECK ?= --conversion-check
+CHECK_FLAG_DIV_BY_ZERO_CHECK ?= --div-by-zero-check
+CHECK_FLAG_FLOAT_OVERFLOW_CHECK ?= --float-overflow-check
+CHECK_FLAG_NAN_CHECK ?= --nan-check
+CHECK_FLAG_POINTER_CHECK ?= --pointer-check
+CHECK_FLAG_POINTER_OVERFLOW_CHECK ?= --pointer-overflow-check
+CHECK_FLAG_POINTER_PRIMITIVE_CHECK ?= --pointer-primitive-check
+CHECK_FLAG_SIGNED_OVERFLOW_CHECK ?= --signed-overflow-check
+CHECK_FLAG_UNDEFINED_SHIFT_CHECK ?= --undefined-shift-check
+CHECK_FLAG_UNSIGNED_OVERFLOW_CHECK ?= --unsigned-overflow-check
+
+CHECKFLAGS += $(CBMC_FLAG_MALLOC_MAY_FAIL)
+CHECKFLAGS += $(CBMC_FLAG_MALLOC_FAIL_NULL)
+CHECKFLAGS += $(CBMC_FLAG_BOUNDS_CHECK)
+CHECKFLAGS += $(CBMC_FLAG_CONVERSION_CHECK)
+CHECKFLAGS += $(CBMC_FLAG_DIV_BY_ZERO_CHECK)
+CHECKFLAGS += $(CBMC_FLAG_FLOAT_OVERFLOW_CHECK)
+CHECKFLAGS += $(CBMC_FLAG_NAN_CHECK)
+CHECKFLAGS += $(CBMC_FLAG_POINTER_CHECK)
+CHECKFLAGS += $(CBMC_FLAG_POINTER_OVERFLOW_CHECK)
+CHECKFLAGS += $(CBMC_FLAG_POINTER_PRIMITIVE_CHECK)
+CHECKFLAGS += $(CBMC_FLAG_SIGNED_OVERFLOW_CHECK)
+CHECKFLAGS += $(CBMC_FLAG_UNDEFINED_SHIFT_CHECK)
+CHECKFLAGS += $(CBMC_FLAG_UNSIGNED_OVERFLOW_CHECK)
 
 # Additional CBMC flags used for coverage checking
 COVERFLAGS +=


### PR DESCRIPTION
*Description of changes:*
This PR introduces a new parameter called `DISABLE_FLAGS` that allows users to disable certain CBMC flags on their proofs. It also adds three pointer-related CBMC flags: `--malloc-fail-null`, `--malloc-may-fail`, and `--pointer-primitive-check`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
