### PR TITLE
Strip whitespace from command line input

### DIFF
--- a/scripts/setup-proof.py
+++ b/scripts/setup-proof.py
@@ -49,10 +49,10 @@ def main():
     logging.basicConfig(format='%(levelname)s: %(message)s')
 
     print("What is the function name?  ", end="")
-    function = input()
+    function = input().strip()
 
     print("What is the source file that defines the function?  ", end="")
-    source_file = os.path.abspath(os.path.expanduser(input()))
+    source_file = os.path.abspath(os.path.expanduser(input().strip()))
 
     source_root = util.read_source_root()
     proof_root = util.read_proof_root()

--- a/scripts/util.py
+++ b/scripts/util.py
@@ -46,7 +46,7 @@ def read_source_root():
     """Read path to source root from console."""
 
     print("What is the path to the source root:  ", end="")
-    return os.path.abspath(os.path.expanduser(input()))
+    return os.path.abspath(os.path.expanduser(input().strip()))
 
 def read_cbmc_root():
     """Read path to cbmc root from console, default to '.'."""
@@ -54,14 +54,14 @@ def read_cbmc_root():
     print("What is the path to the cbmc root "
           "(containing the proofs directory):  ",
           end="")
-    return os.path.abspath(os.path.expanduser(input()))
+    return os.path.abspath(os.path.expanduser(input().strip()))
 
 def read_proof_root():
     """Read path to cbmc root from console, default to '.'."""
 
     print("What is the path to the proof root (the 'proofs' directory): ",
           end="")
-    return os.path.abspath(os.path.expanduser(input()))
+    return os.path.abspath(os.path.expanduser(input().strip()))
 
 ################################################################
 


### PR DESCRIPTION
This simple modification just uses strip() to strip whitespace from script input() from the command line.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
