### PR TITLE
Add malloc flags to coverage checking.

### DIFF
--- a/template-for-repository/proofs/Makefile.common
+++ b/template-for-repository/proofs/Makefile.common
@@ -115,7 +115,7 @@ ifneq ($(strip $(EXTERNAL_SAT_SOLVER)),)
    CHECKFLAGS += --external-sat-solver $(EXTERNAL_SAT_SOLVER)
 endif
 
-# Additional CBMC flags used for property checking
+# Property checking flags
 #
 # Each variable below controls a specific property checking flag
 # within CBMC. If desired, a property flag can be disabled within
@@ -125,9 +125,9 @@ endif
 #     CHECK_FLAG_POINTER_CHECK =
 #
 # would disable the --pointer-check CBMC flag within:
-#
-# a. an entire project when added to Makefile-project-defines
-# b. a specific proof when added to the harness Makefile
+#   * an entire project when added to Makefile-project-defines
+#   * a specific proof when added to the harness Makefile
+
 CBMC_FLAG_MALLOC_MAY_FAIL ?= --malloc-may-fail
 CBMC_FLAG_MALLOC_FAIL_NULL ?= --malloc-fail-null
 CBMC_FLAG_BOUNDS_CHECK ?= --bounds-check
@@ -141,6 +141,8 @@ CBMC_FLAG_POINTER_PRIMITIVE_CHECK ?= --pointer-primitive-check
 CBMC_FLAG_SIGNED_OVERFLOW_CHECK ?= --signed-overflow-check
 CBMC_FLAG_UNDEFINED_SHIFT_CHECK ?= --undefined-shift-check
 CBMC_FLAG_UNSIGNED_OVERFLOW_CHECK ?= --unsigned-overflow-check
+
+# CBMC flags used for property checking
 
 CHECKFLAGS += $(CBMC_FLAG_MALLOC_MAY_FAIL)
 CHECKFLAGS += $(CBMC_FLAG_MALLOC_FAIL_NULL)
@@ -156,8 +158,10 @@ CHECKFLAGS += $(CBMC_FLAG_SIGNED_OVERFLOW_CHECK)
 CHECKFLAGS += $(CBMC_FLAG_UNDEFINED_SHIFT_CHECK)
 CHECKFLAGS += $(CBMC_FLAG_UNSIGNED_OVERFLOW_CHECK)
 
-# Additional CBMC flags used for coverage checking
-COVERFLAGS +=
+# CBMC flags used for coverage checking
+
+COVERFLAGS += $(CBMC_FLAG_MALLOC_MAY_FAIL)
+COVERFLAGS += $(CBMC_FLAG_MALLOC_FAIL_NULL)
 
 # Additional CBMC flag to CBMC control verbosity.
 #


### PR DESCRIPTION
We recently added the flags --malloc-may-fail and --malloc-fail-null to cbmc property checking by default.  The same flags need to be added to coverage checking, too.  

This patch adds the flags to coverage checking and does some minor cleanup of the Makefile.common.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
