### PR TITLE
Update setup scripts to work with litani.

### DIFF
--- a/scripts/setup-proof.py
+++ b/scripts/setup-proof.py
@@ -22,7 +22,7 @@ def read_proof_template(filename):
 
 def write_proof_template(lines, filename, directory):
     with open(os.path.join(directory, filename), "w") as data:
-        data.write('\n'.join(lines)+'\n')
+        data.writelines(line + '\n' for line in lines)
 
 def rename_proof_harness(function, directory):
     shutil.move(os.path.join(directory, "FUNCTION_harness.c"),

--- a/scripts/setup-proof.py
+++ b/scripts/setup-proof.py
@@ -22,7 +22,7 @@ def read_proof_template(filename):
 
 def write_proof_template(lines, filename, directory):
     with open(os.path.join(directory, filename), "w") as data:
-        data.write('\n'.join(lines))
+        data.write('\n'.join(lines)+'\n')
 
 def rename_proof_harness(function, directory):
     shutil.move(os.path.join(directory, "FUNCTION_harness.c"),

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -10,7 +10,30 @@ import os
 
 import util
 
-def create_makefile_template_defines(source_root, proof_root, litani):
+SRCDIR_TEXT = """
+# Absolute path to the root of the source tree.
+#
+SRCDIR ?= $(abspath $(PROOF_ROOT)/{})
+"""
+
+LITANI_TEXT = """
+# Absolute path to the litani script.
+#
+LITANI ?= $(abspath $(PROOF_ROOT)/{})
+"""
+
+PROJECT_TEXT = """
+# Name of this proof project, displayed in proof reports. For example,
+# "s2n" or "Amazon FreeRTOS". For projects with multiple proof roots,
+# this may be overridden on the command-line to Make, for example
+#
+# 	  make PROJECT_NAME="FreeRTOS MQTT" report
+#
+PROJECT_NAME = "{}"
+"""
+
+def create_makefile_template_defines(
+        proof_root, source_root, litani, project_name):
     """Create Makefile-template-defines in the proof root."""
 
     makefile = os.path.join(proof_root, "Makefile-template-defines")
@@ -18,11 +41,11 @@ def create_makefile_template_defines(source_root, proof_root, litani):
         logging.warning("Overwriting %s", makefile)
 
     with open(makefile, "w") as fileobj:
-        print("SRCDIR ?= $(abspath $(PROOF_ROOT)/{})"
-              .format(os.path.relpath(source_root, proof_root)),
+        print(SRCDIR_TEXT.format(os.path.relpath(source_root, proof_root)),
               file=fileobj)
-        print("LITANI ?= $(abspath $(PROOF_ROOT)/{})".format(
-            os.path.relpath(source_root, litani)), file=fileobj)
+        print(LITANI_TEXT.format(os.path.relpath(litani, proof_root)),
+              file=fileobj)
+        print(PROJECT_TEXT.format(project_name), file=fileobj)
 
 def main():
     """Set up the CBMC proof infrastructure."""
@@ -30,13 +53,22 @@ def main():
     logging.basicConfig(format='%(levelname)s: %(message)s')
 
     source_root = util.read_source_root_path()
+
+    # the script is being run in the cbmc root
     cbmc_root = os.path.abspath('.')
-    proof_root = util.read_proof_root_path()
+
+    # the script is creating the proof root
+    proof_root = os.path.abspath('proofs')
+
+    # the script is linking to the litani script within the litani submodule
     litani = util.read_litani_path()
+
+    # the name of the project used in project verification reports
+    project_name = util.read_project_name()
 
     util.copy_repository_templates(cbmc_root)
     create_makefile_template_defines(
-        source_root, proof_root, litani)
+        proof_root, source_root, litani, project_name)
 
 if __name__ == "__main__":
     main()

--- a/scripts/util.py
+++ b/scripts/util.py
@@ -50,16 +50,20 @@ def read_source_root_path():
     return read_path_from_stdin("the source root")
 
 def read_proof_root_path():
-    return read_path_from_stdin("the proof root (the 'proofs' directory)")
+    return read_path_from_stdin("the 'proofs' directory (usually '.')")
 
 def read_litani_path():
-    return read_path_from_stdin("the litani executable")
+    return read_path_from_stdin("the litani script")
 
 def read_source_path():
     return read_path_from_stdin("the source file defining the function")
 
 def read_function_name():
-    print("What is the function name?  ", end="")
+    print("What is the function name? ", end="")
+    return read_from_stdin()
+
+def read_project_name():
+    print("What is the project name? ", end="")
     return read_from_stdin()
 
 ################################################################

--- a/template-for-repository/proofs/Makefile-project-defines
+++ b/template-for-repository/proofs/Makefile-project-defines
@@ -13,14 +13,6 @@
 # Makefile.common.
 ################################################################
 
-# Name of this proof project, displayed in proof reports. For example,
-# "s2n" or "Amazon FreeRTOS". For projects with multiple proof roots,
-# this may be overridden on the command-line to Make, for example
-#
-# 	  make PROJECT_NAME="FreeRTOS MQTT" report
-#
-# PROJECT_NAME =
-
 # Flags to pass to goto-cc for compilation (typically those passed to gcc -c)
 # COMPILE_FLAGS =
 


### PR DESCRIPTION
This patch:

* Moves the definition of PROJECT_NAME to Makefile-template-defines along with SRCDIR and LITANI. The repository templates are copied (or symlinked) into place, but these are all project-level configuration variables that must be defined in order for Makefile.common to run.
* Adds documentation of these configuration variables to Makefile-template-defines.
* Fixes the definition of LITANI
* Cleans up the text of the questions asked by the setup scripts.
* Stops asking for the name of the proofs directory from the top-level setup script since the script itself creates the directory.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
