### PR TITLE
Make it possible to override the use of an external solver

### DIFF
--- a/template-for-repository/proofs/Makefile.common
+++ b/template-for-repository/proofs/Makefile.common
@@ -121,9 +121,19 @@ CBMCDIR ?= $(PROOF_ROOT)/cbmc
 # Default CBMC flags used for property checking and coverage checking
 CBMCFLAGS += --unwind 1 $(CBMC_UNWINDSET) --flush
 
+# Do property checking with the external SAT solver given by
+# EXTERNAL_SAT_SOLVER.  Do coverage checking with the default solver,
+# since coverage checking requires the use of an incremental solver.
+#
+# For a particular proof, if the default solver is faster, do property
+# checking with the default solver by including this definition in the
+# proof Makefile:
+#         USE_EXTERNAL_SAT_SOLVER =
+#
 ifneq ($(strip $(EXTERNAL_SAT_SOLVER)),)
-   CHECKFLAGS += --external-sat-solver $(EXTERNAL_SAT_SOLVER)
+   USE_EXTERNAL_SAT_SOLVER ?= --external-sat-solver $(EXTERNAL_SAT_SOLVER)
 endif
+CHECKFLAGS += $(USE_EXTERNAL_SAT_SOLVER)
 
 # Property checking flags
 #

--- a/template-for-repository/proofs/Makefile.common
+++ b/template-for-repository/proofs/Makefile.common
@@ -124,6 +124,9 @@ CBMCFLAGS += --unwind 1 $(CBMC_UNWINDSET) --flush
 # Do property checking with the external SAT solver given by
 # EXTERNAL_SAT_SOLVER.  Do coverage checking with the default solver,
 # since coverage checking requires the use of an incremental solver.
+# The EXTERNAL_SAT_SOLVER variable is typically set (if it is at all)
+# as an environment variable or as a makefile variable in
+# Makefile-project-defines.
 #
 # For a particular proof, if the default solver is faster, do property
 # checking with the default solver by including this definition in the


### PR DESCRIPTION
The Makefile.common uses the external SAT solver given by the environment variable (or makefile variable) EXTERNAL_SAT_SOLVER for property checking.  This patch makes is possible to override the use of the external solver
and use the default solver for a particular proof (eg, in the event that minisat is actually faster than kissat).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
