### PR TITLE
Add coverage-checking functionality

### DIFF
--- a/template-for-repository/proofs/Makefile-project-defines
+++ b/template-for-repository/proofs/Makefile-project-defines
@@ -35,3 +35,12 @@
 
 # Flags to pass to cmake for building the project
 # ARPA_CMAKE_FLAGS =
+
+# Set ENFORCE_COVERAGE_CHECKS to a non-empty value to enforce that every proof
+# defines an expected CBMC coverage, which will be checked when running the
+# proof. Proofs define an expected coverage by setting the EXPECTED_COVERAGE
+# variable in the proof Makefile to a percentage value, e.g.
+#
+#     EXPECTED_COVERAGE = 98%
+#
+# ENFORCE_COVERAGE_CHECKS =

--- a/template-for-repository/proofs/Makefile.common
+++ b/template-for-repository/proofs/Makefile.common
@@ -565,13 +565,51 @@ $(PROOFDIR)/report: $(LOGDIR)/result.xml $(LOGDIR)/property.xml $(LOGDIR)/covera
 	$(LITANI) add-job \
 	  --command "$$VIEWER2_CMD" \
 	  --inputs $^ \
-	  --outputs $(PROOFDIR)/report \
+	  --outputs \
+	      $(PROOFDIR)/report \
+	      $(PROOFDIR)/report/json/viewer-coverage.json \
 	  --pipeline-name "$(PROOF_UID)" \
 	  --stdout-file $(LOGDIR)/viewer-log.txt \
 	  --interleave-stdout-stderr \
 	  --ci-stage report \
 	  --tags "stats-group:report generation" \
 	  --description "$(PROOF_UID): generating report"
+
+
+ifneq ($(strip $(EXPECTED_COVERAGE)),)
+coverage-check: $(PROOFDIR)/report
+	$(LITANI) add-job \
+	  --inputs $(PROOFDIR)/report/json/viewer-coverage.json \
+	  --pipeline-name "$(PROOF_UID)" \
+	  --interleave-stdout-stderr \
+	  --ci-stage report \
+	  --description "$(PROOF_UID): checking coverage" \
+	  --command \
+	      "./check-coverage  \
+	      --coverage-file $(PROOFDIR)/report/json/viewer-coverage.json \
+	      --expected-coverage $(EXPECTED_COVERAGE)"
+
+else ifneq ($(strip $(ENFORCE_COVERAGE_CHECKS)),)
+coverage-check: $(PROOFDIR)/report
+	$(LITANI) add-job \
+	  --command "echo 'This project enforces coverage checks for all proofs, but this proof has not set a value for EXPECTED_COVERAGE in its Makefile'; /usr/bin/false" \
+	  --inputs $(PROOFDIR)/report/json/viewer-coverage.json \
+	  --pipeline-name "$(PROOF_UID)" \
+	  --ci-stage report \
+	  --description "$(PROOF_UID): checking coverage"
+
+else
+coverage-check: $(PROOFDIR)/report
+	$(LITANI) add-job \
+	  --command "echo 'Skipping coverage check because EXPECTED_COVERAGE was not set in the Makefile for this proof'" \
+	  --inputs $(PROOFDIR)/report/json/viewer-coverage.json \
+	  --pipeline-name "$(PROOF_UID)" \
+	  --ci-stage report \
+	  --description "$(PROOF_UID): checking coverage"
+
+endif
+
+
 
 litani-path:
 	@echo $(LITANI)
@@ -615,7 +653,7 @@ report:
 	$(MAKE) -B _report
 	$(LITANI) run-build
 
-_report2: $(PROOFDIR)/report
+_report2: $(PROOFDIR)/report coverage-check
 report2:
 	$(LITANI) init --project $(PROJECT_NAME)
 	$(MAKE) -B _report2
@@ -645,6 +683,7 @@ veryclean: clean
   arpa \
   clean \
   coverage \
+  coverage-check \
   goto \
   litani-path \
   property \

--- a/template-for-repository/proofs/check-coverage
+++ b/template-for-repository/proofs/check-coverage
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
+import argparse
+import decimal
+import json
+import pathlib
+import sys
+
+
+DESCRIPTION = """
+Return 0 if CBMC coverage for a proof is as high as expected, 1 otherwise
+"""
+
+EPILOG = """
+This script checks reads the JSON coverage file emitted when cbmc-viewer-2 runs
+on CBMC's output files. It compares the coverage value in the JSON file with the
+user-specified expected coverage number.  If CBMC's coverage is below the
+expected value, this script exits abnormally.
+
+CBMC's coverage number is used to ensure that CBMC has explored the code as
+completely as possible, and that the assumptions made in the proof are not so
+restrictive that they prevent CBMC from exercising all code paths. A drop in
+coverage compared to the expected result typically calls for proof-writers to
+investigate and ensure that the proof still holds.
+"""
+
+
+def percentage(string):
+    if string[-1] == "%":
+        string = string[:-1]
+    try:
+        return int(string)
+    except ValueError:
+        raise argparse.ArgumentTypeError("not an integer value: '%s'" % string)
+
+
+def existing_file(path):
+    possible_file = pathlib.Path(path)
+    if not possible_file.exists():
+        raise argparse.ArgumentTypeError("file not found: '%s'" % path)
+    return possible_file
+
+
+def main():
+    pars = argparse.ArgumentParser(description=DESCRIPTION, epilog=EPILOG)
+    for arg in [{
+            "flags": ["--coverage-file"],
+            "help": "JSON file emitted by cbmc-viewer-2 containing coverage info",
+            "type": existing_file,
+            "required": True,
+            "metavar": "F",
+    }, {
+            "flags": ["--expected-coverage"],
+            "help": "integral value as a percent (percentage sign optional)",
+            "type": percentage,
+            "required": True,
+            "metavar": "INT%",
+    }]:
+        flags = arg.pop("flags")
+        pars.add_argument(*flags, **arg)
+    args = pars.parse_args()
+
+    with open(args.coverage_file) as handle:
+        cov_data = json.load(handle)
+    actual_cov = cov_data["viewer-coverage"]["overall_coverage"]["percentage"]
+
+    # The value in the cbmc-viewer JSON file is a float (0.0--1.0). Convert it
+    # into a percentage without incorrectly truncating the fractional part
+    ctx = decimal.Context(prec=2, rounding=decimal.ROUND_HALF_EVEN)
+    cov_dec = ctx.create_decimal(actual_cov)
+    cov_percent = cov_dec * 100
+
+    print("Expected %d%%, got %d%%" % (args.expected_coverage, cov_percent))
+
+    if cov_percent != args.expected_coverage:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR:
* Adds a `check-coverage` program that checks CBMC's coverage for a particular proof against an expected coverage value
* Allows users to define the expected coverage value for a proof in the proof's Makefile
* Adds a Litani job that does the check

**The functionality in this PR depends on version 2 of CBMC viewer.**

Users can now define the `EXPECTED_COVERAGE` variable in proof Makefiles.  If this variable is defined, Litani will run the check-coverage program on the value of `EXPECTED_COVERAGE` to determine whether the proof's coverage was as high as expected.

If the `EXPECTED_COVERAGE` variable is _not_ defined for a proof, the coverage check is skipped. However, if the `ENFORCE_COVERAGE_CHECKS` variable is defined for the whole repository, then proofs that have not defined `EXPECTED_COVERAGE` will instead fail.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
