### PR TITLE
Write Litani output files to local directory

### DIFF
--- a/template-for-repository/.gitignore
+++ b/template-for-repository/.gitignore
@@ -3,6 +3,7 @@ proofs/**/logs
 proofs/**/gotos
 proofs/**/report
 proofs/**/html
+proofs/output
 
 # Emitted by CBMC Viewer
 TAGS-*

--- a/template-for-repository/proofs/run-cbmc-proofs.py
+++ b/template-for-repository/proofs/run-cbmc-proofs.py
@@ -60,6 +60,7 @@ HTML dashboard from the latest Litani run will always be symlinked to
 `output/latest/html/index.html`, so you can keep that page open in
 your browser and reload the page whenever you re-run this script.
 """
+# 70 characters stops here ----------------------------------------> |
 
 
 def get_project_name():

--- a/template-for-repository/proofs/run-cbmc-proofs.py
+++ b/template-for-repository/proofs/run-cbmc-proofs.py
@@ -278,6 +278,19 @@ async def main():
 
     if not args.no_standalone:
         cmd = [str(litani), "init", *init_pools, "--project", args.project_name]
+
+        if "output_directory_flags" in litani_caps:
+            out_prefix = proof_root / "output"
+            out_symlink = out_prefix / "latest"
+            out_index = out_symlink / "html" / "index.html"
+            cmd.extend([
+                "--output-prefix", str(out_prefix),
+                "--output-symlink", str(out_symlink),
+            ])
+            print(
+                "For your convenience, the output of this run will be "
+                "symbolically linked to %s" % str(out_index))
+
         logging.debug(" ".join(cmd))
         proc = subprocess.run(cmd)
         if proc.returncode:

--- a/template-for-repository/proofs/run-cbmc-proofs.py
+++ b/template-for-repository/proofs/run-cbmc-proofs.py
@@ -53,6 +53,12 @@ just the CBMC ones. In that case, you would run `litani init`
 yourself; then run `run-cbmc-proofs --no-standalone`; add any
 additional jobs that you want to execute with `litani add-job`; and
 finally run `litani run-build`.
+
+The litani dashboard will be written under the `output` directory; the
+cbmc-viewer reports remain in the `$PROOF_DIR/report` directory. The
+HTML dashboard from the latest Litani run will always be symlinked to
+`output/latest/html/index.html`, so you can keep that page open in
+your browser and reload the page whenever you re-run this script.
 """
 
 
@@ -288,8 +294,8 @@ async def main():
                 "--output-symlink", str(out_symlink),
             ])
             print(
-                "For your convenience, the output of this run will be "
-                "symbolically linked to %s" % str(out_index))
+                "\nFor your convenience, the output of this run will be "
+                "symbolically linked to %s\n" % str(out_index))
 
         logging.debug(" ".join(cmd))
         proc = subprocess.run(cmd)


### PR DESCRIPTION
When using versions of Litani >=1.7.0, the run script will now make
Litani write its output files to a directory underneath the proof
directory rather than under $TMPDIR. In addition, the latest proof run
will always be symlinked from $PROOFDIR/output/latest, which means that
users can keep $PROOFDIR/output/latest/html/index.html open in their
browser window and reload the page whenever re-running the run script.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
