### PR TITLE
Serialize CBMC jobs for expensive proofs 

### DIFF
--- a/template-for-proof/Makefile
+++ b/template-for-proof/Makefile
@@ -17,4 +17,10 @@ UNWINDSET +=
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
 PROJECT_SOURCES += $(SRCDIR)/<__PATH_TO_SOURCE_FILE__>
 
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
 include <__PATH_TO_MAKEFILE__>/Makefile.common

--- a/template-for-repository/proofs/Makefile.common
+++ b/template-for-repository/proofs/Makefile.common
@@ -141,10 +141,28 @@ CHECKFLAGS += $(USE_EXTERNAL_SAT_SOLVER)
 # Job pools
 # For version of Litani that are new enough (where `litani print-capabilities`
 # prints "pools"), proofs for which `EXPENSIVE = true` is set can be added to a
-# "job pool" that forces only a single "expensive" proof to run at a time. All
-# other proofs will be built in parallel as usual. To enable this feature, set
+# "job pool" that restricts how many expensive proofs are run at a time. All
+# other proofs will be built in parallel as usual.
+#
+# In more detail: all compilation, instrumentation, and report jobs are run with
+# full parallelism as usual, even for expensive proofs. The CBMC jobs for
+# non-expensive proofs are also run in parallel. The only difference is that the
+# CBMC safety checks and coverage checks for expensive proofs are run with a
+# restricted parallelism level. At any one time, only N of these jobs are run at
+# once, amongst all the proofs.
+#
+# To configure N, Litani needs to be initialized with a pool called "expensive".
+# For example, to only run two CBMC safety/coverage jobs at a time from amongst
+# all the proofs, you would initialize litani like
+#         litani init --pools expensive:2
+# The run-cbmc-proofs.py script takes care of this initialization through the
+# --expensive-jobs-parallelism flag.
+#
+# To enable this feature, set
 # the ENABLE_POOLS variable when running Make, like
-#     `make ENABLE_POOLS=true report`
+#         `make ENABLE_POOLS=true report`
+# The run-cbmc-proofs.py script takes care of this through the
+# --restrict-expensive-jobs flag.
 
 ifeq ($(strip $(ENABLE_POOLS)),)
   POOL =

--- a/template-for-repository/proofs/Makefile.common
+++ b/template-for-repository/proofs/Makefile.common
@@ -138,6 +138,22 @@ ifneq ($(strip $(EXTERNAL_SAT_SOLVER)),)
 endif
 CHECKFLAGS += $(USE_EXTERNAL_SAT_SOLVER)
 
+# Job pools
+# For version of Litani that are new enough (where `litani print-capabilities`
+# prints "pools"), proofs for which `EXPENSIVE = true` is set can be added to a
+# "job pool" that forces only a single "expensive" proof to run at a time. All
+# other proofs will be built in parallel as usual. To enable this feature, set
+# the ENABLE_POOLS variable when running Make, like
+#     `make ENABLE_POOLS=true report`
+
+ifeq ($(strip $(ENABLE_POOLS)),)
+  POOL =
+else ifeq ($(strip $(EXPENSIVE)),)
+  POOL =
+else
+  POOL = --pool expensive
+endif
+
 # Property checking flags
 #
 # Each variable below controls a specific property checking flag
@@ -533,6 +549,7 @@ arpa: $(ARPA_BLDDIR)
 
 $(LOGDIR)/result.txt: $(HARNESS_GOTO).goto
 	$(LITANI) add-job \
+	  $(POOL) \
 	  --command \
 	    '$(CBMC) $(CBMC_VERBOSITY) $(CBMCFLAGS) $(CHECKFLAGS) --trace $<' \
 	  --inputs $^ \
@@ -548,6 +565,7 @@ $(LOGDIR)/result.txt: $(HARNESS_GOTO).goto
 
 $(LOGDIR)/result.xml: $(HARNESS_GOTO).goto
 	$(LITANI) add-job \
+	  $(POOL) \
 	  --command \
 	    '$(CBMC) $(CBMC_VERBOSITY) $(CBMCFLAGS) $(CHECKFLAGS) --trace --xml-ui $<' \
 	  --inputs $^ \
@@ -576,6 +594,7 @@ $(LOGDIR)/property.xml: $(HARNESS_GOTO).goto
 
 $(LOGDIR)/coverage.xml: $(HARNESS_GOTO).goto
 	$(LITANI) add-job \
+	  $(POOL) \
 	  --command \
 	    '$(CBMC) $(CBMC_VERBOSITY) $(CBMCFLAGS) $(COVERFLAGS) --cover location --xml-ui $<' \
 	  --inputs $^ \

--- a/template-for-repository/proofs/Makefile.common
+++ b/template-for-repository/proofs/Makefile.common
@@ -537,13 +537,13 @@ $(LOGDIR)/result.txt: $(HARNESS_GOTO).goto
 	    '$(CBMC) $(CBMC_VERBOSITY) $(CBMCFLAGS) $(CHECKFLAGS) --trace $<' \
 	  --inputs $^ \
 	  --outputs $@ \
-	  --pipeline-name "$(PROOF_UID)" \
 	  --ci-stage test \
 	  --stdout-file $@ \
-	  --stderr-file $(LOGDIR)/result-err-log.txt \
 	  --ignore-returns 10 \
 	  --timeout $(CBMC_TIMEOUT) \
+	  --pipeline-name "$(PROOF_UID)" \
 	  --tags "stats-group:safety checks" \
+	  --stderr-file $(LOGDIR)/result-err-log.txt \
 	  --description "$(PROOF_UID): checking safety properties"
 
 $(LOGDIR)/result.xml: $(HARNESS_GOTO).goto
@@ -552,13 +552,13 @@ $(LOGDIR)/result.xml: $(HARNESS_GOTO).goto
 	    '$(CBMC) $(CBMC_VERBOSITY) $(CBMCFLAGS) $(CHECKFLAGS) --trace --xml-ui $<' \
 	  --inputs $^ \
 	  --outputs $@ \
-	  --pipeline-name "$(PROOF_UID)" \
 	  --ci-stage test \
 	  --stdout-file $@ \
-	  --stderr-file $(LOGDIR)/result-err-log.txt \
 	  --ignore-returns 10 \
 	  --timeout $(CBMC_TIMEOUT) \
+	  --pipeline-name "$(PROOF_UID)" \
 	  --tags "stats-group:safety checks" \
+	  --stderr-file $(LOGDIR)/result-err-log.txt \
 	  --description "$(PROOF_UID): checking safety properties"
 
 $(LOGDIR)/property.xml: $(HARNESS_GOTO).goto
@@ -567,11 +567,11 @@ $(LOGDIR)/property.xml: $(HARNESS_GOTO).goto
 	    '$(CBMC) $(CBMC_VERBOSITY) $(CBMCFLAGS) $(CHECKFLAGS) --show-properties --xml-ui $<' \
 	  --inputs $^ \
 	  --outputs $@ \
-	  --pipeline-name "$(PROOF_UID)" \
 	  --ci-stage test \
 	  --stdout-file $@ \
-	  --stderr-file $(LOGDIR)/property-err-log.txt \
 	  --ignore-returns 10 \
+	  --pipeline-name "$(PROOF_UID)" \
+	  --stderr-file $(LOGDIR)/property-err-log.txt \
 	  --description "$(PROOF_UID): printing safety properties"
 
 $(LOGDIR)/coverage.xml: $(HARNESS_GOTO).goto
@@ -580,13 +580,13 @@ $(LOGDIR)/coverage.xml: $(HARNESS_GOTO).goto
 	    '$(CBMC) $(CBMC_VERBOSITY) $(CBMCFLAGS) $(COVERFLAGS) --cover location --xml-ui $<' \
 	  --inputs $^ \
 	  --outputs $@ \
-	  --pipeline-name "$(PROOF_UID)" \
 	  --ci-stage test \
 	  --stdout-file $@ \
-	  --stderr-file $(LOGDIR)/coverage-err-log.txt \
 	  --ignore-returns 10 \
 	  --timeout $(CBMC_TIMEOUT) \
+	  --pipeline-name "$(PROOF_UID)" \
 	  --tags "stats-group:coverage computation" \
+	  --stderr-file $(LOGDIR)/coverage-err-log.txt \
 	  --description "$(PROOF_UID): calculating coverage"
 
 define VIEWER_CMD

--- a/template-for-repository/proofs/run-cbmc-proofs.py
+++ b/template-for-repository/proofs/run-cbmc-proofs.py
@@ -275,6 +275,7 @@ async def configure_proof_dirs(queue, counter, proof_uids, enable_pools):
         pools = ["ENABLE_POOLS=true"] if enable_pools else []
 
         proc = await asyncio.create_subprocess_exec(
+            # Allow interactive tasks to preempt proof configuration
             "nice", "-n", "15", "make", *pools, "-B", "--quiet", "_report",
             cwd=path)
         await proc.wait()


### PR DESCRIPTION
When using new enough versions of Litani (where running
`litani print-capabilities` prints out "pools"), the starter kit will
now run expensive CBMC jobs one at a time. This feature will be used for
any proof whose Makefile contains `EXPENSIVE = true`.

In more detail: all compilation, instrumentation, and report jobs are
run in parallel as usual, even for expensive proofs. The CBMC jobs for
non-expensive proofs are also run in parallel. At any one time, there
will be at most one CBMC safety check or CBMC coverage check running for
one of the expensive proofs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
