### PR TITLE
Enable CBMC memory profile if Litani is new enough

### DIFF
--- a/template-for-repository/proofs/Makefile.common
+++ b/template-for-repository/proofs/Makefile.common
@@ -172,6 +172,14 @@ else
   POOL = --pool expensive
 endif
 
+# Similar to the pool feature above. If Litani is new enough, enable
+# profiling CBMC's memory use.
+ifeq ($(strip $(ENABLE_MEMORY_PROFILING)),)
+  MEMORY_PROFILING =
+else
+  MEMORY_PROFILING = --profile-memory
+endif
+
 # Property checking flags
 #
 # Each variable below controls a specific property checking flag
@@ -603,6 +611,7 @@ $(LOGDIR)/result.txt: $(HARNESS_GOTO).goto
 	  --outputs $@ \
 	  --ci-stage test \
 	  --stdout-file $@ \
+	  $(MEMORY_PROFILING) \
 	  --ignore-returns 10 \
 	  --timeout $(CBMC_TIMEOUT) \
 	  --pipeline-name "$(PROOF_UID)" \
@@ -619,6 +628,7 @@ $(LOGDIR)/result.xml: $(HARNESS_GOTO).goto
 	  --outputs $@ \
 	  --ci-stage test \
 	  --stdout-file $@ \
+	  $(MEMORY_PROFILING) \
 	  --ignore-returns 10 \
 	  --timeout $(CBMC_TIMEOUT) \
 	  --pipeline-name "$(PROOF_UID)" \
@@ -648,6 +658,7 @@ $(LOGDIR)/coverage.xml: $(HARNESS_GOTO).goto
 	  --outputs $@ \
 	  --ci-stage test \
 	  --stdout-file $@ \
+	  $(MEMORY_PROFILING) \
 	  --ignore-returns 10 \
 	  --timeout $(CBMC_TIMEOUT) \
 	  --pipeline-name "$(PROOF_UID)" \


### PR DESCRIPTION
The run script now checks whether Litani supports memory profiling
(which it does since version 1.8.0). If it does, and the user has not
disabled it by passing --no-memory-profile to the run script, the run
script will profile the CBMC safety check and coverage job. This means
that these two jobs will have a box-and-whisker diagram of memory usage
displayed on the front page, as well as a memory trace of the CBMC run
on the pipeline page.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
