### PR TITLE
Don't display runtime graphs for report generation

### DIFF
--- a/template-for-repository/proofs/Makefile.common
+++ b/template-for-repository/proofs/Makefile.common
@@ -686,7 +686,6 @@ $(PROOFDIR)/html: $(LOGDIR)/result.txt $(LOGDIR)/property.xml $(LOGDIR)/coverage
 	  --ci-stage report \
 	  --stdout-file $(LOGDIR)/viewer-log.txt \
 	  --interleave-stdout-stderr \
-	  --tags "stats-group:report generation" \
 	  --description "$(PROOF_UID): generating report"
 
 
@@ -721,7 +720,6 @@ $(PROOFDIR)/report: $(LOGDIR)/result.xml $(LOGDIR)/property.xml $(LOGDIR)/covera
 	  --stdout-file $(LOGDIR)/viewer-log.txt \
 	  --interleave-stdout-stderr \
 	  --ci-stage report \
-	  --tags "stats-group:report generation" \
 	  --description "$(PROOF_UID): generating report"
 
 litani-path:


### PR DESCRIPTION
This is because, when using CBMC Viewer 2, all reports are generated
within seconds; there's no longer any value in rendering the graph.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
