### PR TITLE
Symlink rather than copy run-cbmc-proofs.py

### DIFF
--- a/scripts/util.py
+++ b/scripts/util.py
@@ -21,7 +21,6 @@ COPY_INSTEAD = [
     "Makefile-project-targets",
     "Makefile-project-testing",
     ".gitignore",
-    "run-cbmc-proofs.py",
 ]
 
 ################################################################


### PR DESCRIPTION
Since this script appears to serve most users very well without
modification, we'll now symbolically link to it by default. Users who
need a customized run script can break the symlink manually and copy the
file over to modify it; in the future, we may also implement 'hooks' to
allow users to customize the script without copying it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
