### PR TITLE
Do not print out directory twice

### DIFF
--- a/template-for-repository/proofs/run-cbmc-proofs.py
+++ b/template-for-repository/proofs/run-cbmc-proofs.py
@@ -297,7 +297,10 @@ async def main():
     ] if enable_pools else []
 
     if not args.no_standalone:
-        cmd = [str(litani), "init", *init_pools, "--project", args.project_name]
+        cmd = [
+            str(litani), "init", *init_pools, "--project", args.project_name,
+            "--no-print-out-dir",
+        ]
 
         if "output_directory_flags" in litani_caps:
             out_prefix = proof_root / "output"


### PR DESCRIPTION
The run script prints the path to the Litani output directory surrounded
by newlines, so there is no need for Litani to also print it out.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
