### PR TITLE
bugfix/running-proofs-locally

### DIFF
--- a/template-for-repository/proofs/run-cbmc-proofs.py
+++ b/template-for-repository/proofs/run-cbmc-proofs.py
@@ -287,7 +287,7 @@ async def main():
     args = get_args()
     set_up_logging(args.verbose)
 
-    proof_root = pathlib.Path(__file__).resolve().parent
+    proof_root = pathlib.Path(os.getcwd())
     litani = get_litani_path(proof_root)
 
     litani_caps = get_litani_capabilities(litani)


### PR DESCRIPTION
*Issue #, if available:*
Proofs couldn't run locally for projects running CBMC proofs and had submoduled this repo. 

*Description of changes:*
Change: Point to the `cwd` of the link path for the right proof root directory instead of pointing to the parent folder of the target file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.