### PR TITLE
Added a pointer to the Wiki and some notes about working with

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,42 @@
 # AWS Templates for CBMC Proofs
 
-This repository includes templates and scripts to make it easy to get started
-writing CBMC proofs for your code.  The first script installs proof infrastructure
-in the form of a few directories containing code, templates, and Makefiles that
-facilitate writing CBMC proofs in general.  The second script installs, for a
-particular proof, a directory containing skeletons of all the files needed to start
-writing that proof.
+This repository is a "starter kit" for writing CBMC proofs.
+[CBMC](https://www.cprover.org/cbmc/)
+is a model checker for C code that can prove that the assertions in your code
+are never violated and that your code is free
+of security vulnerabilites like buffer overflow.  In this starter kit,
+* one script ([setup.py](https://github.com/awslabs/aws-templates-for-cbmc-proofs/blob/master/scripts/setup.py))
+  installs into your repository a few directories containing code, templates, and Makefiles that will be
+  useful for every proof you write, and
+* one script ([setup-proof.py](https://github.com/awslabs/aws-templates-for-cbmc-proofs/blob/master/scripts/setup-proof.py))
+  installs, for a particular proof, a single directory containing skeletons of all the files you will need
+  to write that proof.
 
-## Tool setup
+The [starter kit wiki](https://github.com/awslabs/aws-templates-for-cbmc-proofs/wiki) is the
+primary documentation for the starter kit.  It includes tips on how to plan your proof,
+how to write a good proof, and how to debug a failed proof.
+It also includes
+[installation instructions](https://github.com/awslabs/aws-templates-for-cbmc-proofs/wiki/Installation)
+for installing the tools [CBMC](https://github.com/diffblue/cbmc) and
+[CBMC viewer](https://github.com/awslabs/aws-viewer-for-cbmc) that you will need to use the starter kit.
+You should install these tools now.
 
-You will need CBMC and the CBMC Viewer installed to write and view CBMC proofs.
-Follow the installation instructions in the 
-[AWS Templates for CBMC Proofs Wiki](https://github.com/awslabs/aws-templates-for-cbmc-proofs/wiki/Installation)
-to install these and their prerequisites.
+What follows is quick start guide to using the starter kit.
+It sketchs how to install the starter kit and how to start a new proof.
 
-## Proof infrastructure
+## Installing the starter kit
 
-You may want to setup the AWS Templates for CBMC Proofs for a new project,
-or perhaps you just need to know how to access and use the templates with a project
-for which they have already been set up. The next two sections will walk you through
-those two situations.
+If you are working on a new project that does not have the starter kit installed,
+you will need to install it from scratch.
+If you are working on an existing project that already has the starter kit installed,
+you will need to include the starter kit when you clone your project for the first time.
 
-### Proof infrastructure set up for a new project
+### Using the starter kit on a new project
 
-The script scripts/setup.py will set up the infrastructure for CBMC proofs.
+If the starter kit is not already installed in your project, you must
+submodule the starter kit into your project and install it.
+To do this, clone your repository as usual, change directory into your
+repository, and perform the following steps:
 
 * Choose the path to the source root (eg, /usr/project)
 * Choose the path to a directory under the source root that should hold
@@ -41,39 +54,44 @@ The script scripts/setup.py will set up the infrastructure for CBMC proofs.
   python3 aws-templates-for-cbmc-proofs/scripts/setup.py
   ```
   The script will ask for the path to the source root `/usr/project`.
-  The script will install the directories
+  The script will install four directories into `/usr/project/cbmc`:
   * include: contains include files for the proofs
   * sources: contains source code for the proofs
   * stubs: contains stubs for the proofs
   * proofs: contains the proofs themselves (the proof root).
 
-### Proof instrastructure access for an existing project
+See the [setup wiki page](https://github.com/awslabs/aws-templates-for-cbmc-proofs/wiki/CBMC-starter-kit-setup-script) for more details on how to use the script.
 
-If an existing project has been setup following the instructions above and you would like
-to add or edit proofs for the project then start by cloning the repository for the project
-in question. Next, use the following command to get the AWS Templates for CBMC Proofs along
-with any other submodule dependencies the project may have:
+Commit these changes, and you are ready to go.
+
+### Using the starter kit on an existing project
+
+If the starter kit is already installed in your project,
+you just have to remember to include the stater kit whenever you clone your repository.
+To do this, clone your repository as usual, change directory into your
+repository, and run the command:
 
 ````
-git submodule update --init --recursive --checkout
+git submodule update --init --checkout --recursive
 ````
 
-## Proof set up
+## Starting a new proof
 
-The script scripts/setup-proof.py will set up a directory for a CBMC proof.
+Once the starter kit is installed, you start a new proof by running a
+proof setup script.
 
 * Change to a directory under the proof root (/usr/project/cbmc/proofs)
-* Run the script `aws-templates-for-cbmc/scripts/setup-proof.py` and give
+* Run the script `../aws-templates-for-cbmc/scripts/setup-proof.py` and give
   * The name of the function under test.
   * The path to the source file defining the function under test.
-  * The path to the source root
+  * The path to the source root (eg, /usr/project).
 
 The script will create a directory named for the function, and will
-install files needed to run the proof.
-
-You can cut and paste into the files, and type `make` to run and debug
-the proof.  For more details, see [the instructions in the training
-materials repository](github.com/awslabs/aws-training-materials-for-cbmc/SETUP.md).
+install files needed to run the proof. Now you can cut and paste into
+the files, and type `make` to run and debug the proof.
+See the
+[proof setup wiki page](https://github.com/awslabs/aws-templates-for-cbmc-proofs/wiki/CBMC-starter-kit-setup-proof-script)
+for more details on how to use the script and the files it installs.
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,27 @@
 # AWS Templates for CBMC Proofs
 
-This repository includes templates and scripts intended to make it
-easy to get started writing CBMC proofs for your code.  The first
-script installs proof infrastructure in the form of a few directories
-containing code, templates, and Makefiles that facilitate writing CBMC proofs
-in general.  The second script installs, for a particular proof, a directory
-containing skeletons of all the files needed to start writing that proof.
+This repository includes templates and scripts to make it easy to get started
+writing CBMC proofs for your code.  The first script installs proof infrastructure
+in the form of a few directories containing code, templates, and Makefiles that
+facilitate writing CBMC proofs in general.  The second script installs, for a
+particular proof, a directory containing skeletons of all the files needed to start
+writing that proof.
 
-## Proof infrastructure set up
+## Tool setup
+
+You will need CBMC and the CBMC Viewer installed to write and view CBMC proofs.
+Follow the installation instructions in the 
+[AWS Templates for CBMC Proofs Wiki](https://github.com/awslabs/aws-templates-for-cbmc-proofs/wiki/Installation)
+to install these and their prerequisites.
+
+## Proof infrastructure
+
+You may want to setup the AWS Templates for CBMC Proofs for a new project,
+or perhaps you just need to know how to access and use the templates with a project
+for which they have already been set up. The next two sections will walk you through
+those two situations.
+
+### Proof infrastructure set up for a new project
 
 The script scripts/setup.py will set up the infrastructure for CBMC proofs.
 
@@ -32,6 +46,17 @@ The script scripts/setup.py will set up the infrastructure for CBMC proofs.
   * sources: contains source code for the proofs
   * stubs: contains stubs for the proofs
   * proofs: contains the proofs themselves (the proof root).
+
+### Proof instrastructure access for an existing project
+
+If an existing project has been setup following the instructions above and you would like
+to add or edit proofs for the project then start by cloning the repository for the project
+in question. Next, use the following command to get the AWS Templates for CBMC Proofs along
+with any other submodule dependencies the project may have:
+
+````
+git submodule update --init --recursive --checkout
+````
 
 ## Proof set up
 


### PR DESCRIPTION
Added some notes to the README.md that I think would have made my ramp-up easier:

1/ A pointer to the Wiki since that has the very first instructions you need to follow to install the tools you will need. The
very first thing I read is the README, so if there is something else I'm supposed to read first then the README better 
point me at it.

2/ Most people won't be doing the setup of the AWS Templates for a new project, rather they'll be trying to figure out
how to use these templates on a project for which they are already set up, so I added a small section on that.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
