### PR TITLE
Added new setting `RESTRICT_FUNCTION_POINTER`

### DIFF
--- a/template-for-repository/proofs/Makefile.common
+++ b/template-for-repository/proofs/Makefile.common
@@ -304,6 +304,8 @@ REMOVE_FUNCTION_BODY ?=
 # rewritten to a case switch over a finite list of functions.
 # If some possible target functions are omitted from the list a counter
 # example trace will be found by CBMC, i.e. the transformation is sound.
+# If the target functions are file-local symbols, then mangled names must
+# be used.
 RESTRICT_FUNCTION_POINTER ?=
 
 # The project source files (Normally set set in the proof Makefile)

--- a/template-for-repository/proofs/Makefile.common
+++ b/template-for-repository/proofs/Makefile.common
@@ -293,6 +293,19 @@ UNWINDSET ?=
 # The list should include the names of functions being stubbed out.
 REMOVE_FUNCTION_BODY ?=
 
+# CBMC function pointer restriction (Normally set in the proof Makefile)
+#
+# RESTRICT_FUNCTION_POINTER is a list of function pointer restriction 
+# instructions of the form:
+#
+#    <fun_id>.function_pointer_call.<N>/<fun_id>[,<fun_id>]*
+#
+# The function pointer call number <N> in the specified function gets
+# rewritten to a case switch over a finite list of functions.
+# If some possible target functions are omitted from the list a counter
+# example trace will be found by CBMC, i.e. the transformation is sound.
+RESTRICT_FUNCTION_POINTER ?=
+
 # The project source files (Normally set set in the proof Makefile)
 #
 # PROJECT_SOURCES is the list of project source files to compile,
@@ -394,6 +407,7 @@ ifdef UNWINDSET
   endif
 endif
 CBMC_REMOVE_FUNCTION_BODY := $(patsubst %,--remove-function-body %, $(REMOVE_FUNCTION_BODY))
+CBMC_RESTRICT_FUNCTION_POINTER := $(patsubst %,--restrict-function-pointer %, $(RESTRICT_FUNCTION_POINTER))
 
 ################################################################
 # Build targets that make the relevant .goto files
@@ -424,7 +438,7 @@ $(PROOF_GOTO)1.goto: $(PROOF_SOURCES)
 	  --ci-stage build \
 	  --description "$(PROOF_UID): building proof binary"
 
-# Optionally remove function bodies from project sources
+# Optionally restrict function pointers and remove function bodies from project sources
 $(PROJECT_GOTO)2.goto: $(PROJECT_GOTO)1.goto
 ifeq ($(REMOVE_FUNCTION_BODY),"")
 	$(LITANI) add-job \
@@ -437,7 +451,7 @@ ifeq ($(REMOVE_FUNCTION_BODY),"")
 else
 	$(LITANI) add-job \
 	  --command \
-	    '$(GOTO_INSTRUMENT) $(CBMC_VERBOSITY) $(CBMC_REMOVE_FUNCTION_BODY) $^ $@' \
+	    '$(GOTO_INSTRUMENT) $(CBMC_VERBOSITY) $(CBMC_RESTRICT_FUNCTION_POINTER) $(CBMC_REMOVE_FUNCTION_BODY) $^ $@' \
 	  --inputs $^ \
 	  --outputs $@ \
 	  --stdout-file $(LOGDIR)/remove_function_body-log.txt \

--- a/template-for-repository/proofs/Makefile.common
+++ b/template-for-repository/proofs/Makefile.common
@@ -438,7 +438,7 @@ $(PROOF_GOTO)1.goto: $(PROOF_SOURCES)
 	  --ci-stage build \
 	  --description "$(PROOF_UID): building proof binary"
 
-# Optionally restrict function pointers and remove function bodies from project sources
+# Optionally remove function bodies from project sources
 $(PROJECT_GOTO)2.goto: $(PROJECT_GOTO)1.goto
 ifeq ($(REMOVE_FUNCTION_BODY),"")
 	$(LITANI) add-job \
@@ -451,7 +451,7 @@ ifeq ($(REMOVE_FUNCTION_BODY),"")
 else
 	$(LITANI) add-job \
 	  --command \
-	    '$(GOTO_INSTRUMENT) $(CBMC_VERBOSITY) $(CBMC_RESTRICT_FUNCTION_POINTER) $(CBMC_REMOVE_FUNCTION_BODY) $^ $@' \
+	    '$(GOTO_INSTRUMENT) $(CBMC_VERBOSITY) $(CBMC_REMOVE_FUNCTION_BODY) $^ $@' \
 	  --inputs $^ \
 	  --outputs $@ \
 	  --stdout-file $(LOGDIR)/remove_function_body-log.txt \
@@ -461,8 +461,31 @@ else
 	  --description "$(PROOF_UID): removing function bodies from project sources"
 endif
 
+# Optionally restrict function pointers from project sources
+$(PROJECT_GOTO)3.goto: $(PROJECT_GOTO)2.goto
+ifeq ($(RESTRICT_FUNCTION_POINTER),"")
+	$(LITANI) add-job \
+	  --command 'cp $^ $@' \
+	  --inputs $^ \
+	  --outputs $@ \
+	  --pipeline-name "$(PROOF_UID)" \
+	  --ci-stage build \
+	  --description "$(PROOF_UID): not restricting function pointers in project sources"
+else
+	$(LITANI) add-job \
+	  --command \
+	    '$(GOTO_INSTRUMENT) $(CBMC_VERBOSITY) $(CBMC_RESTRICT_FUNCTION_POINTER) $^ $@' \
+	  --inputs $^ \
+	  --outputs $@ \
+	  --stdout-file $(LOGDIR)/restrict_function_pointer-log.txt \
+	  --interleave-stdout-stderr \
+	  --pipeline-name "$(PROOF_UID)" \
+	  --ci-stage build \
+	  --description "$(PROOF_UID): restricting function pointers in project sources"
+endif
+
 # Link project and proof sources into the proof harness
-$(HARNESS_GOTO)1.goto: $(PROOF_GOTO)1.goto $(PROJECT_GOTO)2.goto
+$(HARNESS_GOTO)1.goto: $(PROOF_GOTO)1.goto $(PROJECT_GOTO)3.goto
 	$(LITANI) add-job \
 	  --command '$(GOTO_CC) $(CBMC_VERBOSITY) --function $(HARNESS_ENTRY) $^ -o $@' \
 	  --inputs $^ \


### PR DESCRIPTION
Adds a new setting `RESTRICT_FUNCTION_POINTER` and corresponding `litani` job for targeted function pointer restrictions before a proof.

This feature relies on the `goto-instrument` option `--restrict-function-pointer` option. 

If the proof Makefile specifies:

```
RESTRICT_FUNCTION_POINTER += foo.function_pointer_call.1/bar,baz
```

then the specified function pointer call in function `foo` gets replaced by a switch-case on `bar` and `baz` and an `assert(false)` default case. 

If the target functions `bar` and `baz` are file-local functions then their mangled/decorated names must be used.

This change allows to analyse functions and contracts which involve function pointers.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
