### PR TITLE
Revert to CBMC Viewer 1

### DIFF
--- a/template-for-repository/proofs/Makefile.common
+++ b/template-for-repository/proofs/Makefile.common
@@ -705,6 +705,29 @@ $(LOGDIR)/coverage.xml: $(HARNESS_GOTO).goto
 	  --stderr-file $(LOGDIR)/coverage-err-log.txt \
 	  --description "$(PROOF_UID): calculating coverage"
 
+define VIEWER_CMD
+  $(VIEWER) \
+    --result $(LOGDIR)/result.txt \
+    --block $(LOGDIR)/coverage.xml \
+    --property $(LOGDIR)/property.xml \
+    --srcdir $(SRCDIR) \
+    --goto $(HARNESS_GOTO).goto \
+    --htmldir $(PROOFDIR)/html
+endef
+export VIEWER_CMD
+
+$(PROOFDIR)/html: $(LOGDIR)/result.txt $(LOGDIR)/property.xml $(LOGDIR)/coverage.xml
+	$(LITANI) add-job \
+	  --command "$$VIEWER_CMD" \
+	  --inputs $^ \
+	  --outputs $(PROOFDIR)/html \
+	  --pipeline-name "$(PROOF_UID)" \
+	  --ci-stage report \
+	  --stdout-file $(LOGDIR)/viewer-log.txt \
+	  --interleave-stdout-stderr \
+	  --description "$(PROOF_UID): generating report"
+
+
 # Caution: run make-source before running property and coverage checking
 # The current make-source script removes the goto binary
 $(LOGDIR)/source.json:
@@ -774,8 +797,11 @@ coverage:
 	$(MAKE) -B _coverage
 	$(LITANI) run-build
 
-_report: _report2
-report: report2
+_report: $(PROOFDIR)/html
+report:
+	$(LITANI) init --project $(PROJECT_NAME)
+	$(MAKE) -B _report
+	$(LITANI) run-build
 
 _report2: $(PROOFDIR)/report
 report2:


### PR DESCRIPTION
This reverts commit 82dd40b4c8249c84397fadcf5fc94cd83548b950.

This commit reverts the change to require CBMC Viewer 2 until CBMC Viewer 2 is consistently installed in continuous integration.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
