### PR TITLE
Make Makefile check for CBMC Viewer version

### DIFF
--- a/template-for-repository/proofs/Makefile.common
+++ b/template-for-repository/proofs/Makefile.common
@@ -797,18 +797,15 @@ coverage:
 	$(MAKE) -B _coverage
 	$(LITANI) run-build
 
-_report: $(PROOFDIR)/html
-report:
+_report1: $(PROOFDIR)/html
+_report2: $(PROOFDIR)/report
+_report:
+	cbmc-viewer --version >/dev/null 2>&1 && $(MAKE) -B _report2 || $(MAKE) -B _report1
+
+report report1 report2:
 	$(LITANI) init --project $(PROJECT_NAME)
 	$(MAKE) -B _report
 	$(LITANI) run-build
-
-_report2: $(PROOFDIR)/report
-report2:
-	$(LITANI) init --project $(PROJECT_NAME)
-	$(MAKE) -B _report2
-	$(LITANI) run-build
-
 
 ################################################################
 # Targets to clean up after ourselves


### PR DESCRIPTION
This commit makes the run script query CBMC Viewer's version to decide
which target to run `make` with. This is so that the script can be used
in environments that have either Viewer 1 or Viewer 2 installed without
any other user intervention.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
