### PR TITLE
Add Litani job to check for function declarations

### DIFF
--- a/template-for-repository/proofs/Makefile.common
+++ b/template-for-repository/proofs/Makefile.common
@@ -491,18 +491,28 @@ $(HARNESS_GOTO)1.goto: $(PROOF_GOTO)1.goto $(PROJECT_GOTO)3.goto
 	$(LITANI) add-job \
 	  --command '$(GOTO_CC) $(CBMC_VERBOSITY) --function $(HARNESS_ENTRY) $^ $(LINK_FLAGS) -o $@' \
 	  --inputs $^ \
-	  --outputs $@ \
+	  --outputs $@ $(LOGDIR)/link_proof_project-log.txt \
 	  --stdout-file $(LOGDIR)/link_proof_project-log.txt \
 	  --interleave-stdout-stderr \
 	  --pipeline-name "$(PROOF_UID)" \
 	  --ci-stage build \
 	  --description "$(PROOF_UID): linking project to proof"
 
+.PHONY: $(PROOF_UID)_link_check
+$(PROOF_UID)_link_check: $(HARNESS_GOTO)1.goto
+	$(LITANI) add-job \
+	  --command '$(PROOF_ROOT)check-link-stage --link-log $(LOGDIR)/link_proof_project-log.txt' \
+	  --inputs $(LOGDIR)/link_proof_project-log.txt \
+	  --phony-outputs $@ \
+	  --pipeline-name "$(PROOF_UID)" \
+	  --ci-stage build \
+	  --description "$(PROOF_UID): Checking for function declaration"
+
 # Optionally check function contracts
-$(HARNESS_GOTO)2.goto: $(HARNESS_GOTO)1.goto
+$(HARNESS_GOTO)2.goto: $(HARNESS_GOTO)1.goto $(PROOF_UID)_link_check
 ifeq ($(CHECK_FUNCTION_CONTRACTS),"")
 	$(LITANI) add-job \
-	  --command 'cp $^ $@' \
+	  --command 'cp $< $@' \
 	  --inputs $^ \
 	  --outputs $@ \
 	  --pipeline-name "$(PROOF_UID)" \

--- a/template-for-repository/proofs/check-link-stage
+++ b/template-for-repository/proofs/check-link-stage
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+
+import argparse
+import logging
+import re
+import sys
+import textwrap
+
+
+def get_args():
+    pars = argparse.ArgumentParser()
+    for arg in [{
+            "flags": ["--link-log"],
+            "required": True,
+    }]:
+        flags = arg.pop("flags")
+        pars.add_argument(*flags, **arg)
+    return pars.parse_args()
+
+
+def check_missing_declaration(log):
+    ok = True
+    buf = None
+    pat = re.compile(r"definition in module .+proofs")
+    for line in log:
+        if pat.search(line):
+            ok = False
+            logging.error("The following output:")
+            logging.error("  %s", buf)
+            logging.error("  %s", line)
+            logging.error(textwrap.dedent("""\
+                means that the function being proved was not correctly declared
+                in the proof harness. Ensure that you declare the function (or
+                include the header file where it is declared) in the proof
+                harness. If you are writing a proof for a static function, the
+                function declaration should start with `__CPROVER_file_local`.
+                """))
+        buf = line
+    return ok
+
+
+def get_checks():
+    return [
+        check_missing_declaration,
+    ]
+
+
+def main():
+    logging.basicConfig(format="%(message)s")
+    args = get_args()
+    with open(args.link_log) as handle:
+        link_log = handle.read().splitlines()
+    ok = True
+    for check in get_checks():
+        ok &= check(link_log)
+    sys.exit(0 if ok else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This commit adds a job that ensures that the link job does not complain
about missing function declarations. It checks for a certain warning in
the output of the link job; if this warning is printed, that indicates
that there is no declaration of the function under test in the proof.
This is a user error, so this commit ensures that the proof is aborted
if this happens.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
