### PR TITLE
Support both versions of cbmc viewer

### DIFF
--- a/template-for-repository/proofs/Makefile.common
+++ b/template-for-repository/proofs/Makefile.common
@@ -814,10 +814,15 @@ coverage:
 	@ echo Running 'litani build'
 	$(LITANI) run-build
 
+# Choose the invocation of cbmc-viewer depending on which version of
+# cbmc-viewer is installed.  The --version flag is not implemented in
+# version 1 --- it is an "unrecognized argument" --- but it is
+# implemented in version 2.
 _report1: $(PROOFDIR)/html
 _report2: $(PROOFDIR)/report
 _report:
-	cbmc-viewer --version >/dev/null 2>&1 && $(MAKE) -B _report2 || $(MAKE) -B _report1
+	(cbmc-viewer --version 2>&1 | grep "unrecognized argument" > /dev/null) && \
+		$(MAKE) -B _report1 || $(MAKE) -B _report2
 
 report report1 report2:
 	@ echo Running 'litani init'


### PR DESCRIPTION
This pull request corrects the test used in Makefile.common to test which version of viewer is installed.  The problem was that version 1 incorrectly exited with return code 0 when invoked with the unrecognized argument --version.  This patch tests from the string "unrecognized argument" in the stderr when version 1 is invoked with --version.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
