### PR TITLE
Reorder CBMC passes as required for code contracts

### DIFF
--- a/template-for-repository/proofs/Makefile.common
+++ b/template-for-repository/proofs/Makefile.common
@@ -507,10 +507,59 @@ else
 	  --description "$(PROOF_UID): restricting function pointers in project sources"
 endif
 
+# Optionally fill static variable with unconstrained values
+$(HARNESS_GOTO)3.goto: $(HARNESS_GOTO)2.goto
+ifeq ($(NONDET_STATIC),"")
+	$(LITANI) add-job \
+	  --command 'cp $^ $@' \
+	  --inputs $^ \
+	  --outputs $@ \
+	  --pipeline-name "$(PROOF_UID)" \
+	  --ci-stage build \
+	  --description "$(PROOF_UID): not setting static variables to nondet"
+else
+	$(LITANI) add-job \
+	  --command \
+	    '$(GOTO_INSTRUMENT) $(CBMC_VERBOSITY) $(NONDET_STATIC) $^ $@' \
+	  --inputs $^ \
+	  --outputs $@ \
+	  --stdout-file $(LOGDIR)/nondet_static-log.txt \
+	  --interleave-stdout-stderr \
+	  --pipeline-name "$(PROOF_UID)" \
+	  --ci-stage build \
+	  --description "$(PROOF_UID): setting static variables to nondet"
+endif
+
+# Omit unused functions (sharpens coverage calculations)
+$(HARNESS_GOTO)4.goto: $(HARNESS_GOTO)3.goto
+	$(LITANI) add-job \
+	  --command \
+	    '$(GOTO_INSTRUMENT) $(CBMC_VERBOSITY) --drop-unused-functions $^ $@' \
+	  --inputs $^ \
+	  --outputs $@ \
+	  --stdout-file $(LOGDIR)/drop_unused_functions-log.txt \
+	  --interleave-stdout-stderr \
+	  --pipeline-name "$(PROOF_UID)" \
+	  --ci-stage build \
+	  --description "$(PROOF_UID): dropping unused functions"
+
+# Omit initialization of unused global variables (reduces problem size)
+$(HARNESS_GOTO)5.goto: $(HARNESS_GOTO)4.goto
+	$(LITANI) add-job \
+	  --command \
+	    '$(GOTO_INSTRUMENT) $(CBMC_VERBOSITY) --slice-global-inits $^ $@' \
+	  --inputs $^ \
+	  --outputs $@ \
+	  --stdout-file $(LOGDIR)/slice_global_inits-log.txt \
+	  --interleave-stdout-stderr \
+	  --pipeline-name "$(PROOF_UID)" \
+	  --ci-stage build \
+	  --description "$(PROOF_UID): slicing global initializations"
+
 # Optionally replace function calls with function contracts
 # This must be done before enforcing function contracts,
 # since contract enforcement inlines all function calls.
-$(HARNESS_GOTO)3.goto: $(HARNESS_GOTO)2.goto
+$(HARNESS_GOTO)6.goto: $(HARNESS_GOTO)5.goto
 ifeq ($(USE_FUNCTION_CONTRACTS),"")
 	$(LITANI) add-job \
 	  --command 'cp $^ $@' \
@@ -536,7 +585,7 @@ endif
 # This must be done before enforcing function contracts,
 # since loop unwinding does not replicate writeset snapshots
 # that might be introduced during contract enforcement.
-$(HARNESS_GOTO)4.goto: $(HARNESS_GOTO)3.goto
+$(HARNESS_GOTO)7.goto: $(HARNESS_GOTO)6.goto
 ifeq ($(UNWINDSET),"")
 	$(LITANI) add-job \
 	  --command 'cp $^ $@' \
@@ -559,7 +608,7 @@ else
 endif
 
 # Optionally apply loop contracts
-$(HARNESS_GOTO)5.goto: $(HARNESS_GOTO)4.goto
+$(HARNESS_GOTO)8.goto: $(HARNESS_GOTO)7.goto
 ifneq ($(APPLY_LOOP_CONTRACTS),1)
 	$(LITANI) add-job \
 	  --command 'cp $^ $@' \
@@ -582,7 +631,7 @@ else
 endif
 
 # Optionally check function contracts
-$(HARNESS_GOTO)6.goto: $(HARNESS_GOTO)5.goto
+$(HARNESS_GOTO)9.goto: $(HARNESS_GOTO)8.goto
 ifeq ($(CHECK_FUNCTION_CONTRACTS),"")
 	$(LITANI) add-job \
 	  --command 'cp $^ $@' \
@@ -603,55 +652,6 @@ else
 	  --ci-stage build \
 	  --description "$(PROOF_UID): checking function contracts"
 endif
-
-# Optionally fill static variable with unconstrained values
-$(HARNESS_GOTO)7.goto: $(HARNESS_GOTO)6.goto
-ifeq ($(NONDET_STATIC),"")
-	$(LITANI) add-job \
-	  --command 'cp $^ $@' \
-	  --inputs $^ \
-	  --outputs $@ \
-	  --pipeline-name "$(PROOF_UID)" \
-	  --ci-stage build \
-	  --description "$(PROOF_UID): not setting static variables to nondet"
-else
-	$(LITANI) add-job \
-	  --command \
-	    '$(GOTO_INSTRUMENT) $(CBMC_VERBOSITY) $(NONDET_STATIC) $^ $@' \
-	  --inputs $^ \
-	  --outputs $@ \
-	  --stdout-file $(LOGDIR)/nondet_static-log.txt \
-	  --interleave-stdout-stderr \
-	  --pipeline-name "$(PROOF_UID)" \
-	  --ci-stage build \
-	  --description "$(PROOF_UID): setting static variables to nondet"
-endif
-
-# Omit unused functions (sharpens coverage calculations)
-$(HARNESS_GOTO)8.goto: $(HARNESS_GOTO)7.goto
-	$(LITANI) add-job \
-	  --command \
-	    '$(GOTO_INSTRUMENT) $(CBMC_VERBOSITY) --drop-unused-functions $^ $@' \
-	  --inputs $^ \
-	  --outputs $@ \
-	  --stdout-file $(LOGDIR)/drop_unused_functions-log.txt \
-	  --interleave-stdout-stderr \
-	  --pipeline-name "$(PROOF_UID)" \
-	  --ci-stage build \
-	  --description "$(PROOF_UID): dropping unused functions"
-
-# Omit initialization of unused global variables (reduces problem size)
-$(HARNESS_GOTO)9.goto: $(HARNESS_GOTO)8.goto
-	$(LITANI) add-job \
-	  --command \
-	    '$(GOTO_INSTRUMENT) $(CBMC_VERBOSITY) --slice-global-inits $^ $@' \
-	  --inputs $^ \
-	  --outputs $@ \
-	  --stdout-file $(LOGDIR)/slice_global_inits-log.txt \
-	  --interleave-stdout-stderr \
-	  --pipeline-name "$(PROOF_UID)" \
-	  --ci-stage build \
-	  --description "$(PROOF_UID): slicing global initializations"
 
 # Final name for proof harness
 $(HARNESS_GOTO).goto: $(HARNESS_GOTO)9.goto

--- a/template-for-repository/proofs/Makefile.common
+++ b/template-for-repository/proofs/Makefile.common
@@ -119,11 +119,7 @@ PROOFDIR ?= $(abspath .)
 CBMCDIR ?= $(PROOF_ROOT)/cbmc
 
 # Default CBMC flags used for property checking and coverage checking.
-#
-# Any remaining loops (not unwound and not transformed using contracts)
-# are only unwound once (`--unwind 1`) to avoid CBMC potentially going
-# into an infinite loop in trying to unwind them.
-CBMCFLAGS += --unwind 1 --flush
+CBMCFLAGS += --unwind 1 $(CBMC_UNWINDSET) --flush
 
 # Do property checking with the external SAT solver given by
 # EXTERNAL_SAT_SOLVER.  Do coverage checking with the default solver,
@@ -581,10 +577,26 @@ else
 	  --description "$(PROOF_UID): replacing function calls with function contracts"
 endif
 
-# Optionally unwind specified loops
-# This must be done before enforcing function contracts,
-# since loop unwinding does not replicate writeset snapshots
-# that might be introduced during contract enforcement.
+# Optionally unwind loops
+#
+# Loop unwinding must be done before enforcing function contracts, because
+# loop unwinding does not replicate writeset snapshots that might be
+# introduced during contract enforcement.
+#
+# CBMC has its own model of standard library functions like strcmp.  These
+# functions do not appear in the goto program, they are added to the goto
+# program by CBMC itself.  For this reason, we will need to pass these loop
+# unwinding instructions again to the invocation of CBMC to unwind any loops
+# remaining in functions like strcmp.  We could pull these functions into the
+# goto program with `goto-instrument --add-library`, but enforcing function
+# contracts currently assumes they are missing.
+#
+# The meaning of `--unwindset LOOP:N` depends on the program invoked.  The
+# program goto-instrument will unwind the loop N times.  The program cbmc will
+# unwind the loop N-1 times.  Unwinding with goto-instrument instead of cbmc
+# is obviously sound, but may lead to performance issues if the loops is big
+# and the difference between unwinding N-1 and N is big.
+#
 $(HARNESS_GOTO)7.goto: $(HARNESS_GOTO)6.goto
 ifeq ($(UNWINDSET),"")
 	$(LITANI) add-job \

--- a/template-for-repository/proofs/Makefile.common
+++ b/template-for-repository/proofs/Makefile.common
@@ -118,8 +118,12 @@ PROOFDIR ?= $(abspath .)
 # at $(CBMCDIR)/proofs/Makefile.common.
 CBMCDIR ?= $(PROOF_ROOT)/cbmc
 
-# Default CBMC flags used for property checking and coverage checking
-CBMCFLAGS += --unwind 1 $(CBMC_UNWINDSET) --flush
+# Default CBMC flags used for property checking and coverage checking.
+#
+# Any remaining loops (not unwound and not transformed using contracts)
+# are only unwound once (`--unwind 1`) to avoid CBMC potentially going
+# into an infinite loop in trying to unwind them.
+CBMCFLAGS += --unwind 1 --flush
 
 # Do property checking with the external SAT solver given by
 # EXTERNAL_SAT_SOLVER.  Do coverage checking with the default solver,
@@ -503,31 +507,10 @@ else
 	  --description "$(PROOF_UID): restricting function pointers in project sources"
 endif
 
-# Optionally check function contracts
-$(HARNESS_GOTO)3.goto: $(HARNESS_GOTO)2.goto
-ifeq ($(CHECK_FUNCTION_CONTRACTS),"")
-	$(LITANI) add-job \
-	  --command 'cp $^ $@' \
-	  --inputs $^ \
-	  --outputs $@ \
-	  --pipeline-name "$(PROOF_UID)" \
-	  --ci-stage build \
-	  --description "$(PROOF_UID): not checking function contracts"
-else
-	$(LITANI) add-job \
-	  --command \
-	    '$(GOTO_INSTRUMENT) $(CBMC_VERBOSITY) $(CBMC_CHECK_FUNCTION_CONTRACTS) $^ $@' \
-	  --inputs $^ \
-	  --outputs $@ \
-	  --stdout-file $(LOGDIR)/check_function_contracts-log.txt \
-	  --interleave-stdout-stderr \
-	  --pipeline-name "$(PROOF_UID)" \
-	  --ci-stage build \
-	  --description "$(PROOF_UID): checking function contracts"
-endif
-
 # Optionally replace function calls with function contracts
-$(HARNESS_GOTO)4.goto: $(HARNESS_GOTO)3.goto
+# This must be done before enforcing function contracts,
+# since contract enforcement inlines all function calls.
+$(HARNESS_GOTO)3.goto: $(HARNESS_GOTO)2.goto
 ifeq ($(USE_FUNCTION_CONTRACTS),"")
 	$(LITANI) add-job \
 	  --command 'cp $^ $@' \
@@ -547,6 +530,32 @@ else
 	  --pipeline-name "$(PROOF_UID)" \
 	  --ci-stage build \
 	  --description "$(PROOF_UID): replacing function calls with function contracts"
+endif
+
+# Optionally unwind specified loops
+# This must be done before enforcing function contracts,
+# since loop unwinding does not replicate writeset snapshots
+# that might be introduced during contract enforcement.
+$(HARNESS_GOTO)4.goto: $(HARNESS_GOTO)3.goto
+ifeq ($(UNWINDSET),"")
+	$(LITANI) add-job \
+	  --command 'cp $^ $@' \
+	  --inputs $^ \
+	  --outputs $@ \
+	  --pipeline-name "$(PROOF_UID)" \
+	  --ci-stage build \
+	  --description "$(PROOF_UID): not unwinding loops"
+else
+	$(LITANI) add-job \
+	  --command \
+	    '$(GOTO_INSTRUMENT) $(CBMC_VERBOSITY) $(CBMC_UNWINDSET) $^ $@' \
+	  --inputs $^ \
+	  --outputs $@ \
+	  --stdout-file $(LOGDIR)/unwind_loops-log.txt \
+	  --interleave-stdout-stderr \
+	  --pipeline-name "$(PROOF_UID)" \
+	  --ci-stage build \
+	  --description "$(PROOF_UID): unwinding loops"
 endif
 
 # Optionally apply loop contracts
@@ -572,8 +581,31 @@ else
 	  --description "$(PROOF_UID): applying loop contracts"
 endif
 
-# Optionally fill static variable with unconstrained values
+# Optionally check function contracts
 $(HARNESS_GOTO)6.goto: $(HARNESS_GOTO)5.goto
+ifeq ($(CHECK_FUNCTION_CONTRACTS),"")
+	$(LITANI) add-job \
+	  --command 'cp $^ $@' \
+	  --inputs $^ \
+	  --outputs $@ \
+	  --pipeline-name "$(PROOF_UID)" \
+	  --ci-stage build \
+	  --description "$(PROOF_UID): not checking function contracts"
+else
+	$(LITANI) add-job \
+	  --command \
+	    '$(GOTO_INSTRUMENT) $(CBMC_VERBOSITY) $(CBMC_CHECK_FUNCTION_CONTRACTS) $^ $@' \
+	  --inputs $^ \
+	  --outputs $@ \
+	  --stdout-file $(LOGDIR)/check_function_contracts-log.txt \
+	  --interleave-stdout-stderr \
+	  --pipeline-name "$(PROOF_UID)" \
+	  --ci-stage build \
+	  --description "$(PROOF_UID): checking function contracts"
+endif
+
+# Optionally fill static variable with unconstrained values
+$(HARNESS_GOTO)7.goto: $(HARNESS_GOTO)6.goto
 ifeq ($(NONDET_STATIC),"")
 	$(LITANI) add-job \
 	  --command 'cp $^ $@' \
@@ -596,7 +628,7 @@ else
 endif
 
 # Omit unused functions (sharpens coverage calculations)
-$(HARNESS_GOTO)7.goto: $(HARNESS_GOTO)6.goto
+$(HARNESS_GOTO)8.goto: $(HARNESS_GOTO)7.goto
 	$(LITANI) add-job \
 	  --command \
 	    '$(GOTO_INSTRUMENT) $(CBMC_VERBOSITY) --drop-unused-functions $^ $@' \
@@ -609,7 +641,7 @@ $(HARNESS_GOTO)7.goto: $(HARNESS_GOTO)6.goto
 	  --description "$(PROOF_UID): dropping unused functions"
 
 # Omit initialization of unused global variables (reduces problem size)
-$(HARNESS_GOTO)8.goto: $(HARNESS_GOTO)7.goto
+$(HARNESS_GOTO)9.goto: $(HARNESS_GOTO)8.goto
 	$(LITANI) add-job \
 	  --command \
 	    '$(GOTO_INSTRUMENT) $(CBMC_VERBOSITY) --slice-global-inits $^ $@' \
@@ -622,7 +654,7 @@ $(HARNESS_GOTO)8.goto: $(HARNESS_GOTO)7.goto
 	  --description "$(PROOF_UID): slicing global initializations"
 
 # Final name for proof harness
-$(HARNESS_GOTO).goto: $(HARNESS_GOTO)8.goto
+$(HARNESS_GOTO).goto: $(HARNESS_GOTO)9.goto
 	$(LITANI) add-job \
 	  --command 'cp $< $@' \
 	  --inputs $^ \


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*

Loop unwinding and contract replacement were previously performed _after_ function contract enforcement. There was no dependence between these passes before. However, now they must be done _before_ function contract enforcement:
- Loop unwinding must be done before enforcing function contracts, since loop unwinding does not replicate writeset snapshots that might be introduced during contract enforcement step.
- Function call replacement using contracts must be done before enforcing function contracts, since contract enforcement step inlines all function calls.
- Loop contract application must be done before enforcing function contracts.

Note that since loop unwinding is now done much earlier, the loop "numbers" used in proof `Makefile`s might need to be changed.

A second commit further reorders the slicing passes to reduce the code size on which we do contract instrumentation. In particular, the `--apply-loop-contracts` flag instruments _ALL_ loops that have contracts, even those unreachable from the entry point. This is unnecessary since unreachable loops were sliced away in the next step. After this change, they would be sliced away early on, and only the loops reachable from the entrypoint function would be instrumented.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.