### PR TITLE
Restrict function pointers in linked code, not just project code

### DIFF
--- a/template-for-repository/proofs/Makefile.common
+++ b/template-for-repository/proofs/Makefile.common
@@ -468,8 +468,20 @@ else
 	  --description "$(PROOF_UID): removing function bodies from project sources"
 endif
 
-# Optionally restrict function pointers from project sources
-$(PROJECT_GOTO)3.goto: $(PROJECT_GOTO)2.goto
+# Link project and proof sources into the proof harness
+$(HARNESS_GOTO)1.goto: $(PROOF_GOTO)1.goto $(PROJECT_GOTO)2.goto
+	$(LITANI) add-job \
+	  --command '$(GOTO_CC) $(CBMC_VERBOSITY) --function $(HARNESS_ENTRY) $^ $(LINK_FLAGS) -o $@' \
+	  --inputs $^ \
+	  --outputs $@ \
+	  --stdout-file $(LOGDIR)/link_proof_project-log.txt \
+	  --interleave-stdout-stderr \
+	  --pipeline-name "$(PROOF_UID)" \
+	  --ci-stage build \
+	  --description "$(PROOF_UID): linking project to proof"
+
+# Optionally restrict function pointers
+$(HARNESS_GOTO)2.goto: $(HARNESS_GOTO)1.goto
 ifeq ($(RESTRICT_FUNCTION_POINTER),"")
 	$(LITANI) add-job \
 	  --command 'cp $^ $@' \
@@ -491,20 +503,8 @@ else
 	  --description "$(PROOF_UID): restricting function pointers in project sources"
 endif
 
-# Link project and proof sources into the proof harness
-$(HARNESS_GOTO)1.goto: $(PROOF_GOTO)1.goto $(PROJECT_GOTO)3.goto
-	$(LITANI) add-job \
-	  --command '$(GOTO_CC) $(CBMC_VERBOSITY) --function $(HARNESS_ENTRY) $^ $(LINK_FLAGS) -o $@' \
-	  --inputs $^ \
-	  --outputs $@ \
-	  --stdout-file $(LOGDIR)/link_proof_project-log.txt \
-	  --interleave-stdout-stderr \
-	  --pipeline-name "$(PROOF_UID)" \
-	  --ci-stage build \
-	  --description "$(PROOF_UID): linking project to proof"
-
 # Optionally check function contracts
-$(HARNESS_GOTO)2.goto: $(HARNESS_GOTO)1.goto
+$(HARNESS_GOTO)3.goto: $(HARNESS_GOTO)2.goto
 ifeq ($(CHECK_FUNCTION_CONTRACTS),"")
 	$(LITANI) add-job \
 	  --command 'cp $^ $@' \
@@ -527,7 +527,7 @@ else
 endif
 
 # Optionally replace function calls with function contracts
-$(HARNESS_GOTO)3.goto: $(HARNESS_GOTO)2.goto
+$(HARNESS_GOTO)4.goto: $(HARNESS_GOTO)3.goto
 ifeq ($(USE_FUNCTION_CONTRACTS),"")
 	$(LITANI) add-job \
 	  --command 'cp $^ $@' \
@@ -550,7 +550,7 @@ else
 endif
 
 # Optionally apply loop contracts
-$(HARNESS_GOTO)4.goto: $(HARNESS_GOTO)3.goto
+$(HARNESS_GOTO)5.goto: $(HARNESS_GOTO)4.goto
 ifneq ($(APPLY_LOOP_CONTRACTS),1)
 	$(LITANI) add-job \
 	  --command 'cp $^ $@' \
@@ -573,7 +573,7 @@ else
 endif
 
 # Optionally fill static variable with unconstrained values
-$(HARNESS_GOTO)5.goto: $(HARNESS_GOTO)4.goto
+$(HARNESS_GOTO)6.goto: $(HARNESS_GOTO)5.goto
 ifeq ($(NONDET_STATIC),"")
 	$(LITANI) add-job \
 	  --command 'cp $^ $@' \
@@ -596,7 +596,7 @@ else
 endif
 
 # Omit unused functions (sharpens coverage calculations)
-$(HARNESS_GOTO)6.goto: $(HARNESS_GOTO)5.goto
+$(HARNESS_GOTO)7.goto: $(HARNESS_GOTO)6.goto
 	$(LITANI) add-job \
 	  --command \
 	    '$(GOTO_INSTRUMENT) $(CBMC_VERBOSITY) --drop-unused-functions $^ $@' \
@@ -609,7 +609,7 @@ $(HARNESS_GOTO)6.goto: $(HARNESS_GOTO)5.goto
 	  --description "$(PROOF_UID): dropping unused functions"
 
 # Omit initialization of unused global variables (reduces problem size)
-$(HARNESS_GOTO)7.goto: $(HARNESS_GOTO)6.goto
+$(HARNESS_GOTO)8.goto: $(HARNESS_GOTO)7.goto
 	$(LITANI) add-job \
 	  --command \
 	    '$(GOTO_INSTRUMENT) $(CBMC_VERBOSITY) --slice-global-inits $^ $@' \
@@ -622,7 +622,7 @@ $(HARNESS_GOTO)7.goto: $(HARNESS_GOTO)6.goto
 	  --description "$(PROOF_UID): slicing global initializations"
 
 # Final name for proof harness
-$(HARNESS_GOTO).goto: $(HARNESS_GOTO)7.goto
+$(HARNESS_GOTO).goto: $(HARNESS_GOTO)8.goto
 	$(LITANI) add-job \
 	  --command 'cp $< $@' \
 	  --inputs $^ \


### PR DESCRIPTION
This commit modifies Makefile.common to instrument the linked goto program with function pointer restrictions, and not just the project code before linking with the proof code.  The problem was when the function pointer being restricted was in the project code and the stub for the function was in the proof code.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
