### PR TITLE
Apply --object-bits during goto-cc compilation

### DIFF
--- a/template-for-repository/proofs/Makefile.common
+++ b/template-for-repository/proofs/Makefile.common
@@ -402,6 +402,7 @@ COMMA :=,
 # Set C compiler defines
 
 CBMCFLAGS += --object-bits $(CBMC_OBJECT_BITS)
+COMPILE_FLAGS += --object-bits $(CBMC_OBJECT_BITS)
 
 DEFINES += -DCBMC=1
 DEFINES += -DCBMC_OBJECT_BITS=$(CBMC_OBJECT_BITS)


### PR DESCRIPTION
Signed-off-by: Felipe R. Monteiro felisous@amazon.com

*Issue #, if available:*
N/A.

*Description of changes:*

We must ensure we use the same object size during compilation and CBMC invocation.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
